### PR TITLE
feat(container): add package flags, DRY up functions

### DIFF
--- a/cmd/autoremove.go
+++ b/cmd/autoremove.go
@@ -41,18 +41,6 @@ func NewAutoRemoveCommand() *cobra.Command {
 }
 
 func autoRemove(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "autoremove")...)
 	command = append(command, args...)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -42,18 +42,6 @@ func NewCleanCommand() *cobra.Command {
 }
 
 func clean(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "clean")...)
 	command = append(command, args...)

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -40,18 +40,6 @@ func NewEnterCommand() *cobra.Command {
 }
 
 func enter(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	if err := core.EnterContainer(container); err != nil {
 		log.Default().Fatal("Failed to enter container: ", err)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -42,18 +42,6 @@ func NewExportCommand() *cobra.Command {
 }
 
 func export(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	core.ExportDesktopEntry(container, args[0])
 	return nil

--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -42,18 +42,6 @@ func NewInitializeCommand() *cobra.Command {
 }
 
 func initialize(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	if core.ContainerExists(container) {
 		log.Default().Printf(`Container already exists. Do you want to re-initialize it?\ 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -52,22 +52,10 @@ func NewInstallCommand() *cobra.Command {
 }
 
 func install(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
 	no_export := cmd.Flag("no-export").Value.String() == "true"
 	assume_yes := cmd.Flag("assume-yes").Value.String() == "true"
 	fix_broken := cmd.Flag("fix-broken").Value.String() == "true"
 	sideload := cmd.Flag("sideload").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "install")...)
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -46,18 +46,6 @@ func NewListCommand() *cobra.Command {
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "list")...)
 

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -42,18 +42,6 @@ func NewPurgeCommand() *cobra.Command {
 }
 
 func purge(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "purge")...)
 	command = append(command, args...)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -44,18 +44,6 @@ func NewRemoveCommand() *cobra.Command {
 }
 
 func remove(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "remove")...)
 	command = append(command, args...)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// package level variables for viper flags
+var aur, dnf, apk bool
+
+// package level variable for container name,
+// set in root command's PersistentPreRun function
+var container string = "default"
+
+func NewApxCommand(Version string) *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "apx",
+		Short:   "Apx is a package manager with support for multiple sources allowing you to install packages in a managed container.",
+		Version: Version,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			container = getContainer()
+		},
+	}
+	rootCmd.PersistentFlags().BoolVar(&aur, "aur", false, "Install packages from the AUR (Arch User Repository).")
+	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
+	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
+
+	rootCmd.AddCommand(NewInitializeCommand())
+	rootCmd.AddCommand(NewAutoRemoveCommand())
+	rootCmd.AddCommand(NewInstallCommand())
+	rootCmd.AddCommand(NewCleanCommand())
+	rootCmd.AddCommand(NewEnterCommand())
+	rootCmd.AddCommand(NewExportCommand())
+	rootCmd.AddCommand(NewListCommand())
+	rootCmd.AddCommand(NewPurgeCommand())
+	rootCmd.AddCommand(NewRemoveCommand())
+	rootCmd.AddCommand(NewRunCommand())
+	rootCmd.AddCommand(NewSearchCommand())
+	rootCmd.AddCommand(NewShowCommand())
+	rootCmd.AddCommand(NewUnexportCommand())
+	rootCmd.AddCommand(NewUpdateCommand())
+	rootCmd.AddCommand(NewUpgradeCommand())
+	return rootCmd
+}
+
+func getContainer() string {
+	container := "default"
+	if aur {
+		container = "aur"
+	} else if dnf {
+		container = "dnf"
+	} else if apk {
+		container = "apk"
+	}
+	return container
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,18 +42,7 @@ func NewRunCommand() *cobra.Command {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
 
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 	core.RunContainer(container, args...)
 
 	return nil

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -42,18 +42,6 @@ func NewSearchCommand() *cobra.Command {
 }
 
 func search(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "search")...)
 	command = append(command, args...)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -42,18 +42,6 @@ func NewShowCommand() *cobra.Command {
 }
 
 func show(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "show")...)
 	command = append(command, args...)

--- a/cmd/unexport.go
+++ b/cmd/unexport.go
@@ -42,18 +42,6 @@ func NewUnexportCommand() *cobra.Command {
 }
 
 func unexport(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	return core.RemoveDesktopEntry(container, args[0])
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -43,18 +43,6 @@ func NewUpdateCommand() *cobra.Command {
 }
 
 func update(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "update")...)
 	command = append(command, args...)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -43,18 +43,6 @@ func NewUpgradeCommand() *cobra.Command {
 }
 
 func upgrade(cmd *cobra.Command, args []string) error {
-	aur := cmd.Flag("aur").Value.String() == "true"
-	dnf := cmd.Flag("dnf").Value.String() == "true"
-	apk := cmd.Flag("apk").Value.String() == "true"
-
-	container := "default"
-	if aur {
-		container = "aur"
-	} else if dnf {
-		container = "dnf"
-	} else if apk {
-		container = "apk"
-	}
 
 	command := append([]string{}, core.GetPkgCommand(container, "upgrade")...)
 	command = append(command, args...)

--- a/main.go
+++ b/main.go
@@ -55,35 +55,9 @@ Commands:
 	upgrade     Upgrade the system by installing/upgrading available packages`)
 }
 
-func newApxCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:     "apx",
-		Short:   "Apx is a package manager with support for multiple sources allowing you to install packages in a managed container.",
-		Version: Version,
-	}
-}
-
 func main() {
-	rootCmd := newApxCommand()
-	rootCmd.PersistentFlags().Bool("aur", false, "Install packages from the AUR (Arch User Repository).")
-	rootCmd.PersistentFlags().Bool("dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
-	rootCmd.PersistentFlags().Bool("apk", false, "Install packages from the Alpine repository.")
+	rootCmd := cmd.NewApxCommand(Version)
 
-	rootCmd.AddCommand(cmd.NewInitializeCommand())
-	rootCmd.AddCommand(cmd.NewAutoRemoveCommand())
-	rootCmd.AddCommand(cmd.NewInstallCommand())
-	rootCmd.AddCommand(cmd.NewCleanCommand())
-	rootCmd.AddCommand(cmd.NewEnterCommand())
-	rootCmd.AddCommand(cmd.NewExportCommand())
-	rootCmd.AddCommand(cmd.NewListCommand())
-	rootCmd.AddCommand(cmd.NewPurgeCommand())
-	rootCmd.AddCommand(cmd.NewRemoveCommand())
-	rootCmd.AddCommand(cmd.NewRunCommand())
-	rootCmd.AddCommand(cmd.NewSearchCommand())
-	rootCmd.AddCommand(cmd.NewShowCommand())
-	rootCmd.AddCommand(cmd.NewUnexportCommand())
-	rootCmd.AddCommand(cmd.NewUpdateCommand())
-	rootCmd.AddCommand(cmd.NewUpgradeCommand())
 	rootCmd.SetHelpFunc(help)
 	rootCmd.Execute()
 }


### PR DESCRIPTION
If applied, this patch will add package level variables for container type and name, then set them in a PersistentPreRun function of the root command, applied to all children of the root command. Deletes much code.