### PR TITLE
feat(containers): allow arbitrary container names

### DIFF
--- a/cmd/autoremove.go
+++ b/cmd/autoremove.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func autoRemoveUsage(*cobra.Command) error {
@@ -42,10 +41,10 @@ func NewAutoRemoveCommand() *cobra.Command {
 
 func autoRemove(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "autoremove")...)
+	command := append([]string{}, container.GetPkgCommand("autoremove")...)
 	command = append(command, args...)
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/autoremove.go
+++ b/cmd/autoremove.go
@@ -9,25 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func autoRemoveUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Remove all unused packages automatically.
-Usage:
-  apx autoremove [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Usage:
-  apx autoremove
-`)
-	return nil
-}
 
 func NewAutoRemoveCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -36,7 +19,6 @@ func NewAutoRemoveCommand() *cobra.Command {
 		Short:   "Remove all unused packages automatically",
 		RunE:    autoRemove,
 	}
-	//cmd.SetUsageFunc(autoRemoveUsage)
 	return cmd
 }
 

--- a/cmd/autoremove.go
+++ b/cmd/autoremove.go
@@ -31,11 +31,12 @@ Usage:
 
 func NewAutoRemoveCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "autoremove",
-		Short: "Remove all unused packages automatically",
-		RunE:  autoRemove,
+		Example: "apx autoremove",
+		Use:     "autoremove",
+		Short:   "Remove all unused packages automatically",
+		RunE:    autoRemove,
 	}
-	cmd.SetUsageFunc(autoRemoveUsage)
+	//cmd.SetUsageFunc(autoRemoveUsage)
 	return cmd
 }
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func cleanUsage(*cobra.Command) error {
@@ -43,10 +42,10 @@ func NewCleanCommand() *cobra.Command {
 
 func clean(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "clean")...)
+	command := append([]string{}, container.GetPkgCommand("clean")...)
 	command = append(command, args...)
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func cleanUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Clean the apx package manager cache.
-
-Usage:
-  apx clean [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx clean
-`)
-	return nil
-}
 
 func NewCleanCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewCleanCommand() *cobra.Command {
 		Short:   "Clean the apx package manager cache",
 		RunE:    clean,
 	}
-	//cmd.SetUsageFunc(cleanUsage)
 	return cmd
 }
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewCleanCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clean",
-		Short: "Clean the apx package manager cache",
-		RunE:  clean,
+		Example: "apx clean",
+		Use:     "clean",
+		Short:   "Clean the apx package manager cache",
+		RunE:    clean,
 	}
-	cmd.SetUsageFunc(cleanUsage)
+	//cmd.SetUsageFunc(cleanUsage)
 	return cmd
 }
 

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -13,7 +13,6 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func enterUsage(*cobra.Command) error {
@@ -41,7 +40,7 @@ func NewEnterCommand() *cobra.Command {
 
 func enter(cmd *cobra.Command, args []string) error {
 
-	if err := core.EnterContainer(container); err != nil {
+	if err := container.Enter(); err != nil {
 		log.Default().Fatal("Failed to enter container: ", err)
 		return err
 	}

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -30,11 +30,12 @@ Options:
 
 func NewEnterCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "enter",
-		Short: "Enter in the container shell",
-		RunE:  enter,
+		Example: "apx enter",
+		Use:     "enter",
+		Short:   "Enter in the container shell",
+		RunE:    enter,
 	}
-	cmd.SetUsageFunc(enterUsage)
+	//	cmd.SetUsageFunc(enterUsage)
 	return cmd
 }
 

--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -15,19 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func enterUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Enter in the container shell.
-
-Usage:
-  apx enter [options]
-
-Options:
-  -h, --help            Show this help message and exit
-`)
-	return nil
-}
-
 func NewEnterCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Example: "apx enter",
@@ -35,7 +22,6 @@ func NewEnterCommand() *cobra.Command {
 		Short:   "Enter in the container shell",
 		RunE:    enter,
 	}
-	//	cmd.SetUsageFunc(enterUsage)
 	return cmd
 }
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func exportUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Export/Recreate a program's desktop entry from a managed container.
-
-Usage:
-  apx export <program> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx export htop
-`)
-	return nil
-}
 
 func NewExportCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewExportCommand() *cobra.Command {
 		Short:   "Export/Recreate a program's desktop entry from a managed container",
 		RunE:    export,
 	}
-	//	cmd.SetUsageFunc(exportUsage)
 	return cmd
 }
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func exportUsage(*cobra.Command) error {
@@ -43,6 +42,6 @@ func NewExportCommand() *cobra.Command {
 
 func export(cmd *cobra.Command, args []string) error {
 
-	core.ExportDesktopEntry(container, args[0])
+	container.ExportDesktopEntry(args[0])
 	return nil
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewExportCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "export",
-		Short: "Export/Recreate a program's desktop entry from a managed container",
-		RunE:  export,
+		Example: "apx export htop",
+		Use:     "export <program>",
+		Short:   "Export/Recreate a program's desktop entry from a managed container",
+		RunE:    export,
 	}
-	cmd.SetUsageFunc(exportUsage)
+	//	cmd.SetUsageFunc(exportUsage)
 	return cmd
 }
 

--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func initializeUsage(*cobra.Command) error {
@@ -43,7 +42,7 @@ func NewInitializeCommand() *cobra.Command {
 
 func initialize(cmd *cobra.Command, args []string) error {
 
-	if core.ContainerExists(container) {
+	if container.Exists() {
 		log.Default().Printf(`Container already exists. Do you want to re-initialize it?\ 
 This operation will remove everything, including your files in the container. [y/N] `)
 
@@ -56,10 +55,10 @@ This operation will remove everything, including your files in the container. [y
 		}
 	}
 
-	if err := core.RemoveContainer(container); err != nil {
+	if err := container.Remove(); err != nil {
 		panic(err)
 	}
-	if err := core.CreateContainer(container); err != nil {
+	if err := container.Create(); err != nil {
 		panic(err)
 	}
 

--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -17,19 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func initializeUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Initialize the managed container.
-
-Usage:
-  apx init [options]
-
-Options:
-  -h, --help            Show this help message and exit
-`)
-	return nil
-}
-
 func NewInitializeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Example: "apx init",
@@ -37,7 +24,6 @@ func NewInitializeCommand() *cobra.Command {
 		Short:   "Initialize the managed container",
 		RunE:    initialize,
 	}
-	//cmd.SetUsageFunc(initializeUsage)
 	return cmd
 }
 

--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -32,11 +32,12 @@ Options:
 
 func NewInitializeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize the managed container",
-		RunE:  initialize,
+		Example: "apx init",
+		Use:     "init",
+		Short:   "Initialize the managed container",
+		RunE:    initialize,
 	}
-	cmd.SetUsageFunc(initializeUsage)
+	//cmd.SetUsageFunc(initializeUsage)
 	return cmd
 }
 

--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -43,10 +43,10 @@ This operation will remove everything, including your files in the container. [y
 	}
 
 	if err := container.Remove(); err != nil {
-		panic(err)
+		log.Fatal(fmt.Errorf("error removing container: %v", err))
 	}
 	if err := container.Create(); err != nil {
-		panic(err)
+		log.Fatal(fmt.Errorf("error creating container: %v", err))
 	}
 
 	return nil

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -38,11 +38,13 @@ Examples:
 
 func NewInstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "install",
+		Example: `apx install htop git
+apx install --sideload /path/to/file.deb`,
+		Use:   "install <packages>",
 		Short: "Install packages inside a managed container",
 		RunE:  install,
 	}
-	cmd.SetUsageFunc(installUsage)
+	//cmd.SetUsageFunc(installUsage)
 	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	cmd.Flags().BoolP("fix-broken", "f", false, "Fix broken deps before installing.")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -15,27 +15,6 @@ import (
 	"github.com/vanilla-os/apx/core"
 )
 
-func installUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Install packages inside a managed container.
-
-Usage:
-  apx install [options] <packages>
-
-Options:
-  -h, --help            Show this help message and exit
-  -y, --assume-yes      Proceed without manual confirmation.
-  -f, --fix-broken      Fix broken deps before installing.
-  --no-export           Do not export a desktop entry after the installation.
-  --sideload [path]     Install a package from a local file.
-
-Examples:
-  apx install htop git
-  apx install --sideload /path/to/file.deb
-`)
-	return nil
-}
-
 func NewInstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Example: `apx install htop git
@@ -44,7 +23,6 @@ apx install --sideload /path/to/file.deb`,
 		Short: "Install packages inside a managed container",
 		RunE:  install,
 	}
-	//cmd.SetUsageFunc(installUsage)
 	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	cmd.Flags().BoolP("fix-broken", "f", false, "Fix broken deps before installing.")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -57,7 +57,7 @@ func install(cmd *cobra.Command, args []string) error {
 	fix_broken := cmd.Flag("fix-broken").Value.String() == "true"
 	sideload := cmd.Flag("sideload").Value.String() == "true"
 
-	command := append([]string{}, core.GetPkgCommand(container, "install")...)
+	command := append([]string{}, container.GetPkgCommand("install")...)
 
 	if assume_yes {
 		command = append(command, "-y")
@@ -79,7 +79,7 @@ func install(cmd *cobra.Command, args []string) error {
 		command = append(command, args...)
 	}
 
-	err := core.RunContainer(container, command...)
+	err := container.Run(command...)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func install(cmd *cobra.Command, args []string) error {
 
 	if !sideload {
 		for _, pkg := range args {
-			core.ExportDesktopEntry(container, pkg)
+			container.ExportDesktopEntry(pkg)
 		}
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func listUsage(*cobra.Command) error {
@@ -47,7 +46,7 @@ func NewListCommand() *cobra.Command {
 
 func list(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "list")...)
+	command := append([]string{}, container.GetPkgCommand("list")...)
 
 	if cmd.Flag("upgradable").Value.String() == "true" {
 		command = append(command, "--upgradable")
@@ -58,7 +57,7 @@ func list(cmd *cobra.Command, args []string) error {
 
 	command = append(command, args...)
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -36,7 +36,7 @@ func NewListCommand() *cobra.Command {
 		Short: "List installed packages.",
 		RunE:  list,
 	}
-	cmd.SetUsageFunc(listUsage)
+	//cmd.SetUsageFunc(listUsage)
 	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().BoolP("upgradable", "u", false, "List only upgradable packages.")
 	cmd.Flags().BoolP("installed", "i", false, "List only installed packages.")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func listUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	List installed packages.
-
-Usage:
-  apx list [options]
-
-Options:
-  -h, --help            Show this help message and exit
-  -u, --upgradable      Show only upgradable packages
-  -i, --installed       Show only installed packages
-
-`)
-	return nil
-}
 
 func NewListCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -36,7 +18,6 @@ func NewListCommand() *cobra.Command {
 		Short: "List installed packages.",
 		RunE:  list,
 	}
-	//cmd.SetUsageFunc(listUsage)
 	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().BoolP("upgradable", "u", false, "List only upgradable packages.")
 	cmd.Flags().BoolP("installed", "i", false, "List only installed packages.")

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func purgeUsage(*cobra.Command) error {
@@ -43,10 +42,10 @@ func NewPurgeCommand() *cobra.Command {
 
 func purge(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "purge")...)
+	command := append([]string{}, container.GetPkgCommand("purge")...)
 	command = append(command, args...)
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewPurgeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "purge",
-		Short: "Purge packages inside a managed container",
-		RunE:  purge,
+		Example: "apx purge htop",
+		Use:     "purge <packages>",
+		Short:   "Purge packages inside a managed container",
+		RunE:    purge,
 	}
-	cmd.SetUsageFunc(purgeUsage)
+	//cmd.SetUsageFunc(purgeUsage)
 	return cmd
 }
 

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func purgeUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Purge packages inside a managed container.
-
-Usage:
-  apx purge <packages> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx purge htop
-`)
-	return nil
-}
 
 func NewPurgeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewPurgeCommand() *cobra.Command {
 		Short:   "Purge packages inside a managed container",
 		RunE:    purge,
 	}
-	//cmd.SetUsageFunc(purgeUsage)
 	return cmd
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func removeUsage(*cobra.Command) error {
@@ -45,20 +44,20 @@ func NewRemoveCommand() *cobra.Command {
 
 func remove(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "remove")...)
+	command := append([]string{}, container.GetPkgCommand("remove")...)
 	command = append(command, args...)
 
 	if cmd.Flag("assume-yes").Value.String() == "true" {
 		command = append(command, "-y")
 	}
 
-	err := core.RunContainer(container, command...)
+	err := container.Run(command...)
 	if err != nil {
 		return err
 	}
 
 	for _, pkg := range args {
-		core.RemoveDesktopEntry(container, pkg)
+		container.RemoveDesktopEntry(pkg)
 	}
 
 	return nil

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewRemoveCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove",
-		Short: "Remove packages inside a managed container.",
-		RunE:  remove,
+		Example: "apx remove htop",
+		Use:     "remove <packages>",
+		Short:   "Remove packages inside a managed container.",
+		RunE:    remove,
 	}
-	cmd.SetUsageFunc(removeUsage)
+	//cmd.SetUsageFunc(removeUsage)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 
 	return cmd

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func removeUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Remove packages inside a managed container.
-
-Usage:
-  apx remove <packages> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx remove htop
-`)
-	return nil
-}
 
 func NewRemoveCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewRemoveCommand() *cobra.Command {
 		Short:   "Remove packages inside a managed container.",
 		RunE:    remove,
 	}
-	//cmd.SetUsageFunc(removeUsage)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vanilla-os/apx/core"
 )
 
 // package level variables for viper flags
@@ -9,7 +10,8 @@ var aur, dnf, apk bool
 
 // package level variable for container name,
 // set in root command's PersistentPreRun function
-var container string = "default"
+var container *core.Container
+var name string
 
 func NewApxCommand(Version string) *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -23,6 +25,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&aur, "aur", false, "Install packages from the AUR (Arch User Repository).")
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
+	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create named container with this name.")
 
 	rootCmd.AddCommand(NewInitializeCommand())
 	rootCmd.AddCommand(NewAutoRemoveCommand())
@@ -42,14 +45,19 @@ func NewApxCommand(Version string) *cobra.Command {
 	return rootCmd
 }
 
-func getContainer() string {
-	container := "default"
+func getContainer() *core.Container {
+	var kind core.ContainerType = core.DEFAULT
 	if aur {
-		container = "aur"
+		kind = core.AUR
 	} else if dnf {
-		container = "dnf"
+		kind = core.DNF
 	} else if apk {
-		container = "apk"
+		kind = core.APK
 	}
-	return container
+	if len(name) > 0 {
+		return core.NewNamedContainer(kind, name)
+	} else {
+		return core.NewContainer(kind)
+	}
+
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&aur, "aur", false, "Install packages from the AUR (Arch User Repository).")
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
-	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create named container with this name.")
+	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create or use custom container with this name.")
 
 	rootCmd.AddCommand(NewInitializeCommand())
 	rootCmd.AddCommand(NewAutoRemoveCommand())

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run",
-		Short: "Run a program inside a managed container.",
-		RunE:  run,
+		Example: "apx run htop",
+		Use:     "run <program>",
+		Short:   "Run a program inside a managed container.",
+		RunE:    run,
 	}
-	cmd.SetUsageFunc(runUsage)
+	//cmd.SetUsageFunc(runUsage)
 	return cmd
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func runUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Run a program inside a managed container.
-
-Usage:
-  apx run <program> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx run htop
-`)
-	return nil
-}
 
 func NewRunCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func runUsage(*cobra.Command) error {
@@ -43,7 +42,7 @@ func NewRunCommand() *cobra.Command {
 
 func run(cmd *cobra.Command, args []string) error {
 
-	core.RunContainer(container, args...)
+	container.Run(args...)
 
 	return nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,6 @@ func NewRunCommand() *cobra.Command {
 		Short:   "Run a program inside a managed container.",
 		RunE:    run,
 	}
-	//cmd.SetUsageFunc(runUsage)
 	return cmd
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewSearchCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "search",
-		Short: "Search for packages in a managed container.",
-		RunE:  search,
+		Example: "apx search neovim",
+		Use:     "search <packages>",
+		Short:   "Search for packages in a managed container.",
+		RunE:    search,
 	}
-	cmd.SetUsageFunc(searchUsage)
+	//	cmd.SetUsageFunc(searchUsage)
 	return cmd
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func searchUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Search for packages in a managed container.
-
-Usage:
-  apx search <packages> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx search htop
-`)
-	return nil
-}
 
 func NewSearchCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewSearchCommand() *cobra.Command {
 		Short:   "Search for packages in a managed container.",
 		RunE:    search,
 	}
-	//	cmd.SetUsageFunc(searchUsage)
 	return cmd
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func searchUsage(*cobra.Command) error {
@@ -43,10 +42,10 @@ func NewSearchCommand() *cobra.Command {
 
 func search(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "search")...)
+	command := append([]string{}, container.GetPkgCommand("search")...)
 	command = append(command, args...)
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func showUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Show details about a package.
-
-Usage:
-  apx show <package> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx show htop
-`)
-	return nil
-}
 
 func NewShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewShowCommand() *cobra.Command {
 		Short:   "Show details about a package",
 		RunE:    show,
 	}
-	//cmd.SetUsageFunc(showUsage)
 	return cmd
 }
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func showUsage(*cobra.Command) error {
@@ -43,10 +42,10 @@ func NewShowCommand() *cobra.Command {
 
 func show(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "show")...)
+	command := append([]string{}, container.GetPkgCommand("show")...)
 	command = append(command, args...)
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show",
-		Short: "Show details about a package",
-		RunE:  show,
+		Example: "apx show htop",
+		Use:     "show <package>",
+		Short:   "Show details about a package",
+		RunE:    show,
 	}
-	cmd.SetUsageFunc(showUsage)
+	//cmd.SetUsageFunc(showUsage)
 	return cmd
 }
 

--- a/cmd/unexport.go
+++ b/cmd/unexport.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewUnexportCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unexport",
-		Short: "Unexport/Remove a program's desktop entry from a managed container",
-		RunE:  unexport,
+		Example: "apx unexport code",
+		Use:     "unexport <program>",
+		Short:   "Unexport/Remove a program's desktop entry from a managed container",
+		RunE:    unexport,
 	}
-	cmd.SetUsageFunc(unexportUsage)
+	//	cmd.SetUsageFunc(unexportUsage)
 	return cmd
 }
 

--- a/cmd/unexport.go
+++ b/cmd/unexport.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func unexportUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Unexport/Remove a program's desktop entry from a managed container.
-
-Usage:
-  apx unexport <program> [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx unexport htop
-`)
-	return nil
-}
 
 func NewUnexportCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewUnexportCommand() *cobra.Command {
 		Short:   "Unexport/Remove a program's desktop entry from a managed container",
 		RunE:    unexport,
 	}
-	//	cmd.SetUsageFunc(unexportUsage)
 	return cmd
 }
 

--- a/cmd/unexport.go
+++ b/cmd/unexport.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func unexportUsage(*cobra.Command) error {
@@ -43,5 +42,5 @@ func NewUnexportCommand() *cobra.Command {
 
 func unexport(cmd *cobra.Command, args []string) error {
 
-	return core.RemoveDesktopEntry(container, args[0])
+	return container.RemoveDesktopEntry(args[0])
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func updateUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Update the list of available packages.
-
-Usage:
-  apx update [options]
-
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx update
-`)
-	return nil
-}
 
 func NewUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewUpdateCommand() *cobra.Command {
 		Short:   "Update the list of available packages",
 		RunE:    update,
 	}
-	//cmd.SetUsageFunc(updateUsage)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	return cmd
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewUpdateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update the list of available packages",
-		RunE:  update,
+		Example: "apx update",
+		Use:     "update",
+		Short:   "Update the list of available packages",
+		RunE:    update,
 	}
-	cmd.SetUsageFunc(updateUsage)
+	//cmd.SetUsageFunc(updateUsage)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	return cmd
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func updateUsage(*cobra.Command) error {
@@ -44,14 +43,14 @@ func NewUpdateCommand() *cobra.Command {
 
 func update(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "update")...)
+	command := append([]string{}, container.GetPkgCommand("update")...)
 	command = append(command, args...)
 
 	if cmd.Flag("assume-yes").Value.String() == "true" {
 		command = append(command, "-y")
 	}
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -9,26 +9,8 @@ package cmd
 */
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-func upgradeUsage(*cobra.Command) error {
-	fmt.Print(`Description: 
-	Upgrade the system by installing/upgrading available packages.
-
-Usage:
-  apx upgrade [options]
-  
-Options:
-  -h, --help            Show this help message and exit
-
-Examples:
-  apx upgrade
-`)
-	return nil
-}
 
 func NewUpgradeCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +19,6 @@ func NewUpgradeCommand() *cobra.Command {
 		Short:   "Upgrade the system by installing/upgrading available packages.",
 		RunE:    upgrade,
 	}
-	//	cmd.SetUsageFunc(upgradeUsage)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	return cmd
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/vanilla-os/apx/core"
 )
 
 func upgradeUsage(*cobra.Command) error {
@@ -44,14 +43,14 @@ func NewUpgradeCommand() *cobra.Command {
 
 func upgrade(cmd *cobra.Command, args []string) error {
 
-	command := append([]string{}, core.GetPkgCommand(container, "upgrade")...)
+	command := append([]string{}, container.GetPkgCommand("upgrade")...)
 	command = append(command, args...)
 
 	if cmd.Flag("assume-yes").Value.String() == "true" {
 		command = append(command, "-y")
 	}
 
-	core.RunContainer(container, command...)
+	container.Run(command...)
 
 	return nil
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,11 +32,12 @@ Examples:
 
 func NewUpgradeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "upgrade",
-		Short: "Upgrade the system by installing/upgrading available packages.",
-		RunE:  upgrade,
+		Example: "apx upgrade",
+		Use:     "upgrade",
+		Short:   "Upgrade the system by installing/upgrading available packages.",
+		RunE:    upgrade,
 	}
-	cmd.SetUsageFunc(upgradeUsage)
+	//	cmd.SetUsageFunc(upgradeUsage)
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	return cmd
 }

--- a/core/connection.go
+++ b/core/connection.go
@@ -15,8 +15,5 @@ import (
 
 func CheckConnection() bool {
 	_, err := http.Get("https://google.com") // TODO: use a better way to check connection
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }

--- a/core/container.go
+++ b/core/container.go
@@ -128,7 +128,7 @@ func GetDistroboxVersion() (version string, err error) {
 
 	splitted := strings.Split(string(output), "distrobox: ")
 	if len(splitted) != 2 {
-		return "", errors.New("Can't retrieve distrobox version")
+		return "", errors.New("can't retrieve distrobox version")
 	}
 
 	return splitted[1], nil
@@ -162,7 +162,7 @@ func (c *Container) Enter() error {
 
 	if !c.Exists() {
 		log.Default().Printf("Managed container does not exist.\nTry: apx init")
-		return errors.New("Managed container does not exist")
+		return errors.New("managed container does not exist")
 	}
 
 	container_name := c.GetContainerName()

--- a/core/container.go
+++ b/core/container.go
@@ -77,7 +77,7 @@ func (c *Container) GetContainerName() (name string) {
 	case APK:
 		cn.WriteString("apx_managed_apk")
 	default:
-		panic("Unknown container not supported")
+		log.Fatal(fmt.Errorf("unspecified container type"))
 	}
 	if len(c.customName) > 0 {
 		cn.WriteString("_")
@@ -96,7 +96,8 @@ func ContainerManager() string {
 		return "podman"
 	}
 
-	panic("No container engine found. Please install Podman or Docker.")
+	log.Fatal("no container engine found. Please install Podman or Docker.")
+	return ""
 }
 
 func GetHostImage() (img string, err error) {
@@ -217,7 +218,7 @@ func (c *Container) Create() error {
 	//err = cmd.Run()
 	_, err = cmd.Output()
 	if err != nil {
-		log.Panic(err)
+		log.Fatalf("error creating container: %v", err)
 	}
 
 	spinner.Stop()
@@ -247,7 +248,7 @@ func (c *Container) Stop() error {
 	spinner.Stop()
 
 	if err != nil {
-		log.Panic(err)
+		log.Fatalf("error stopping container: %v", err)
 	}
 
 	log.Default().Println("Container stopped")

--- a/core/essentials.go
+++ b/core/essentials.go
@@ -23,7 +23,7 @@ func init() {
 	if err != nil {
 		fmt.Println(`One or more core components are not available. 
 Please refer to our documentation at https://documentation.vanillaos.org/`)
-		panic(err)
+		log.Fatal(err)
 	}
 }
 
@@ -33,12 +33,12 @@ func CheckContainerTools() error {
 	podman := exec.Command("which", "podman")
 
 	if distrobox != nil {
-		return errors.New(`Distrobox is not installed. Please install it.`)
+		return errors.New(`distrobox is not installed`)
 	}
 
 	if err := docker.Run(); err != nil {
 		if err := podman.Run(); err != nil {
-			return errors.New(`No container engine found. Please install Podman or Docker.`)
+			return errors.New(`container engine (docker or podman) not found`)
 		}
 	}
 

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -170,7 +171,7 @@ func GetLatestYay() string {
 	url := "https://api.github.com/repos/Jguer/yay/releases/latest"
 	resp, err := http.Get(url)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error getting latest yay: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -180,7 +181,7 @@ func GetLatestYay() string {
 	assets_url := result["assets_url"].(string)
 	resp, err = http.Get(assets_url)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error downloading yay assets: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -192,39 +193,40 @@ func GetLatestYay() string {
 			return asset["browser_download_url"].(string)
 		}
 	}
-	panic("Failed to install yay. No asset found.")
+	log.Fatal("no yay asset found for architecture x86_64")
+	return ""
 }
 
 func DownloadYay() {
 	url := GetLatestYay()
 	resp, err := http.Get(url)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error downloading yay: %v", err)
 	}
 	defer resp.Body.Close()
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		panic(err)
+		log.Fatalf("error detecting user home directory: %v", err)
 	}
 
 	yay_dir := fmt.Sprintf("%v/.local/src/yay", home)
 	if _, err := os.Stat(yay_dir); os.IsNotExist(err) {
 		err = os.MkdirAll(yay_dir, 0755)
 		if err != nil {
-			panic(err)
+			log.Fatalf("error creating yay src directory: %v", err)
 		}
 	}
 
 	yay_file := fmt.Sprintf("%v/yay.tar.gz", yay_dir)
 	out, err := os.Create(yay_file)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error creating yay tar: %v", err)
 	}
 	defer out.Close()
 
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error writing yay tar: %v", err)
 	}
 }

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -21,15 +21,15 @@ func GetPkgManager() []string {
 	return []string{bin}
 }
 
-func GetPkgCommand(container string, command string) []string {
-	switch container {
-	case "aur":
+func (c *Container) GetPkgCommand(command string) []string {
+	switch c.containerType {
+	case AUR:
 		return GetAurPkgCommand(command)
-	case "dnf":
+	case DNF:
 		return GetDnfPkgCommand(command)
-	case "apk":
+	case APK:
 		return GetApkPkgCommand(command)
-	case "default":
+	case DEFAULT:
 		return GetDefaultPkgCommand(command)
 	default:
 		return nil

--- a/main.go
+++ b/main.go
@@ -57,7 +57,6 @@ Commands:
 
 func main() {
 	rootCmd := cmd.NewApxCommand(Version)
-
-	rootCmd.SetHelpFunc(help)
+	//	rootCmd.SetHelpFunc(help)
 	rootCmd.Execute()
 }

--- a/man/apx.1
+++ b/man/apx.1
@@ -31,6 +31,8 @@ Options:
     --aur           Install packages from the AUR repository
     --dnf           Install packages from the Fedora repository
     --apk           Install packages from the Alpine repository
+    -n, --name      Create or use custom container with this name.
+
 
 Commands:
     autoremove      Remove all unused packages

--- a/settings/config.go
+++ b/settings/config.go
@@ -11,6 +11,7 @@ package settings
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
 
@@ -36,7 +37,7 @@ func init() {
 		image, pkgmanager, err := GetHostInfo()
 
 		if err != nil {
-			panic("Unsupported setup detected, set a default distro and package manager in the config file")
+			log.Fatal("Unsupported setup detected, set a default distro and package manager in the config file")
 		}
 
 		Cnf = &Config{ContainerName: "apx_managed", Image: image, PkgManager: pkgmanager}
@@ -44,11 +45,11 @@ func init() {
 		err = viper.Unmarshal(&Cnf)
 
 		if err != nil {
-			panic("Config error!\n" + err.Error())
+			log.Fatalf("Config error: %v\n" + err.Error())
 		}
 
 		if Cnf.ContainerName == "" || Cnf.Image == "" || Cnf.PkgManager == "" {
-			panic("Config error!\ncontainer_name, image and pkgmanager have to be set")
+			log.Fatal("Config error!\ncontainer_name, image and pkgmanager have to be set")
 		}
 	}
 


### PR DESCRIPTION
If merged, this patch allows arbitrary extra managed containers specified with `--name` flag.