### PR TITLE
Add --apt to use Ubuntu containers when default is set to something else and reduce the config file to the bare minimum and make it optional

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ import (
 )
 
 // package level variables for viper flags
-var aur, dnf, apk bool
+var apt, aur, dnf, apk bool
 
 // package level variable for container name,
 // set in root command's PersistentPreRun function
@@ -20,6 +20,7 @@ func NewApxCommand(Version string) *cobra.Command {
 			container = getContainer()
 		},
 	}
+	rootCmd.PersistentFlags().BoolVar(&apt, "apt", false, "Install packages from the Ubuntu repository.")
 	rootCmd.PersistentFlags().BoolVar(&aur, "aur", false, "Install packages from the AUR (Arch User Repository).")
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
@@ -44,7 +45,9 @@ func NewApxCommand(Version string) *cobra.Command {
 
 func getContainer() string {
 	container := "default"
-	if aur {
+	if apt {
+		container = "apt"
+	} else if aur {
 		container = "aur"
 	} else if dnf {
 		container = "dnf"

--- a/config/config.json
+++ b/config/config.json
@@ -1,22 +1,5 @@
 {
-    "container": {
-        "name": "apx_managed",
-        "image": "",
-        "path": "",
-        "update": ""
-    },
-    "pkgmanager": {
-        "bin": "/usr/bin/apt",
-        "sudo": true,
-        "cmdAutoremove": "autoremove",
-        "cmdClean": "clean",
-        "cmdInstall": "install",
-        "cmdList": "list",
-        "cmdPurge": "purge",
-        "cmdRemove": "remove",
-        "cmdSearch": "search",
-        "cmdShow": "show",
-        "cmdUpdate": "update",
-        "cmdUpgrade": "upgrade"
-    }
+    "container_name": "apx_managed",
+    "image": "docker.io/library/ubuntu",
+    "pkgmanager": "apt"
 }

--- a/core/container.go
+++ b/core/container.go
@@ -36,30 +36,10 @@ func ContainerManager() string {
 	panic("No container engine found. Please install Podman or Docker.")
 }
 
-func GetHostImage() (img string, err error) {
-	if settings.Cnf.Container.Image != "" {
-		return settings.Cnf.Container.Image, nil
-	}
-
-	distro_raw, err := exec.Command("lsb_release", "-is").Output()
-	if err != nil {
-		return "", err
-	}
-	distro := strings.ToLower(strings.Trim(string(distro_raw), "\r\n"))
-
-	release_raw, err := exec.Command("lsb_release", "-rs").Output()
-	if err != nil {
-		return "", err
-	}
-	release := strings.ToLower(strings.Trim(string(release_raw), "\r\n"))
-
-	return fmt.Sprintf("%v:%v", distro, release), nil
-}
-
 func GetContainerImage(container string) (image string, err error) {
 	switch container {
 	case "default":
-		return GetHostImage()
+		return settings.Cnf.Image, nil
 	case "apt":
 		return "docker.io/library/ubuntu", nil
 	case "aur":
@@ -78,7 +58,7 @@ func GetContainerImage(container string) (image string, err error) {
 func GetContainerName(container string) (name string) {
 	switch container {
 	case "default":
-		return "apx_managed"
+		return settings.Cnf.ContainerName
 	case "apt":
 		return "apx_managed_apt"
 	case "aur":

--- a/core/container.go
+++ b/core/container.go
@@ -60,6 +60,8 @@ func GetContainerImage(container string) (image string, err error) {
 	switch container {
 	case "default":
 		return GetHostImage()
+	case "apt":
+		return "docker.io/library/ubuntu", nil
 	case "aur":
 		return "docker.io/library/archlinux", nil
 	case "dnf":
@@ -76,17 +78,15 @@ func GetContainerImage(container string) (image string, err error) {
 func GetContainerName(container string) (name string) {
 	switch container {
 	case "default":
-		name := "apx_managed"
-		return name
+		return "apx_managed"
+	case "apt":
+		return "apx_managed_apt"
 	case "aur":
-		name := "apx_managed_aur"
-		return name
+		return "apx_managed_aur"
 	case "dnf":
-		name := "apx_managed_dnf"
-		return name
+		return "apx_managed_dnf"
 	case "apk":
-		name := "apx_managed_apk"
-		return name
+		return "apx_managed_apk"
 	default:
 		panic("Unknown container not supported")
 	}

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -11,16 +11,6 @@ import (
 	"github.com/vanilla-os/apx/settings"
 )
 
-func GetPkgManager() []string {
-	sudo := settings.Cnf.PkgManager.Sudo
-	bin := settings.Cnf.PkgManager.Bin
-
-	if sudo {
-		return []string{"sudo", bin}
-	}
-	return []string{bin}
-}
-
 func GetPkgCommand(container string, command string) []string {
 	switch container {
 	case "apt":
@@ -39,38 +29,49 @@ func GetPkgCommand(container string, command string) []string {
 }
 
 func GetDefaultPkgCommand(command string) []string {
-	res := GetPkgManager()
-	switch command {
-	case "autoremove":
-		res = append(res, settings.Cnf.PkgManager.CmdAutoremove)
-	case "clean":
-		res = append(res, settings.Cnf.PkgManager.CmdClean)
-	case "install":
-		res = append(res, settings.Cnf.PkgManager.CmdInstall)
-	case "list":
-		res = append(res, settings.Cnf.PkgManager.CmdList)
-	case "purge":
-		res = append(res, settings.Cnf.PkgManager.CmdPurge)
-	case "remove":
-		res = append(res, settings.Cnf.PkgManager.CmdRemove)
-	case "search":
-		res = append(res, settings.Cnf.PkgManager.CmdSearch)
-	case "show":
-		res = append(res, settings.Cnf.PkgManager.CmdShow)
-	case "update":
-		res = append(res, settings.Cnf.PkgManager.CmdUpdate)
-	case "upgrade":
-		res = append(res, settings.Cnf.PkgManager.CmdUpgrade)
+	pkgmanager := settings.Cnf.PkgManager
+
+	switch pkgmanager {
+	case "apt":
+		return GetAptPkgCommand(command)
+	case "aur":
+		return GetAurPkgCommand(command)
+	case "dnf":
+		return GetDnfPkgCommand(command)
+	case "apk":
+		return GetApkPkgCommand(command)
 	default:
-		return nil
+		return []string{"echo", pkgmanager + " is not implemented yet!"}
 	}
-	return res
 }
 
 func GetAptPkgCommand(command string) []string {
 	bin := "apt"
 
-	return []string{"sudo", bin, command}
+	switch command {
+	case "autoremove":
+		return []string{"sudo", bin, "autoremove"}
+	case "clean":
+		return []string{"sudo", bin, "clean"}
+	case "install":
+		return []string{"sudo", bin, "install"}
+	case "list":
+		return []string{"sudo", bin, "list"}
+	case "purge":
+		return []string{"sudo", bin, "purge"}
+	case "remove":
+		return []string{"sudo", bin, "remove"}
+	case "search":
+		return []string{"sudo", bin, "search"}
+	case "show":
+		return []string{"sudo", bin, "show"}
+	case "update":
+		return []string{"sudo", bin, "update"}
+	case "upgrade":
+		return []string{"sudo", bin, "upgrade"}
+	default:
+		return nil
+	}
 }
 
 func GetAurPkgCommand(command string) []string {

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -23,6 +23,8 @@ func GetPkgManager() []string {
 
 func GetPkgCommand(container string, command string) []string {
 	switch container {
+	case "apt":
+		return GetAptPkgCommand(command)
 	case "aur":
 		return GetAurPkgCommand(command)
 	case "dnf":
@@ -63,7 +65,12 @@ func GetDefaultPkgCommand(command string) []string {
 		return nil
 	}
 	return res
+}
 
+func GetAptPkgCommand(command string) []string {
+	bin := "apt"
+
+	return []string{"sudo", bin, command}
 }
 
 func GetAurPkgCommand(command string) []string {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func help(cmd *cobra.Command, args []string) {
 Options:
 	-h, --help    Show this help message and exit
 	-v, --version Show version and exit
+	--apt	    Install packages from the Ubuntu repository
 	--aur	    Install packages from the AUR repository
 	--dnf	    Install packages from the Fedora repository
 	--apk	    Install packages from the Alpine repository

--- a/settings/config.go
+++ b/settings/config.go
@@ -10,34 +10,17 @@ package settings
 */
 
 import (
+	"fmt"
+	"os/exec"
+	"strings"
+
 	"github.com/spf13/viper"
 )
 
 type Config struct {
-	Container  ContainerConfig  `json:"container"`
-	PkgManager PkgManagerConfig `json:"pkg_manager"`
-}
-
-type ContainerConfig struct {
-	Name   string `json:"name"`
-	Image  string `json:"container_image,omitempty"`
-	Path   string `json:"container_path"`
-	Update string `json:"container_update"`
-}
-
-type PkgManagerConfig struct {
-	Bin           string `json:"pkgmanager_bin"`
-	Sudo          bool   `json:"pkgmanager_sudo"`
-	CmdAutoremove string `json:"pkgmanager_cmdAutoremove"`
-	CmdClean      string `json:"pkgmanager_cmdClean"`
-	CmdInstall    string `json:"pkgmanager_cmdInstall"`
-	CmdList       string `json:"pkgmanager_cmdList"`
-	CmdPurge      string `json:"pkgmanager_cmdPurge"`
-	CmdRemove     string `json:"pkgmanager_cmdRemove"`
-	CmdSearch     string `json:"pkgmanager_cmdSearch"`
-	CmdShow       string `json:"pkgmanager_cmdShow"`
-	CmdUpdate     string `json:"pkgmanager_cmdUpdate"`
-	CmdUpgrade    string `json:"pkgmanager_cmdUpgrade"`
+	ContainerName string `json:"container_name"`
+	Image         string `json:"image"`
+	PkgManager    string `json:"pkgmanager"`
 }
 
 var Cnf *Config
@@ -50,13 +33,23 @@ func init() {
 	err := viper.ReadInConfig()
 
 	if err != nil {
-		panic("Config error!")
-	}
+		image, pkgmanager, err := GetHostInfo()
 
-	err = viper.Unmarshal(&Cnf)
+		if err != nil {
+			panic("Unsupported setup detected, set a default distro and package manager in the config file")
+		}
 
-	if err != nil {
-		panic("Config error!\n" + err.Error())
+		Cnf = &Config{ContainerName: "apx_managed", Image: image, PkgManager: pkgmanager}
+	} else {
+		err = viper.Unmarshal(&Cnf)
+
+		if err != nil {
+			panic("Config error!\n" + err.Error())
+		}
+
+		if Cnf.ContainerName == "" || Cnf.Image == "" || Cnf.PkgManager == "" {
+			panic("Config error!\ncontainer_name, image and pkgmanager have to be set")
+		}
 	}
 
 	// fmt.Println("==========================")
@@ -67,4 +60,36 @@ func init() {
 	// fmt.Println("Container update command:", Cnf.Container.Update)
 	// fmt.Println("Package manager bin:", Cnf.PkgManager.Bin)
 	// fmt.Println("==========================")
+}
+
+func GetHostInfo() (img string, pkgmanager string, err error) {
+	distro_raw, err := exec.Command("lsb_release", "-is").Output()
+	if err != nil {
+		return "", "", err
+	}
+	distro := strings.ToLower(strings.Trim(string(distro_raw), "\r\n"))
+
+	release_raw, err := exec.Command("lsb_release", "-rs").Output()
+	if err != nil {
+		return "", "", err
+	}
+	release := strings.ToLower(strings.Trim(string(release_raw), "\r\n"))
+
+	img = fmt.Sprintf("%v:%v", distro, release)
+
+	pkgmanager = ""
+	switch distro {
+	case "ubuntu":
+		pkgmanager = "apt"
+	case "archlinux":
+		pkgmanager = "yay"
+	case "fedora":
+		pkgmanager = "dnf"
+	case "alpine":
+		pkgmanager = "apk"
+	default:
+		return "", "", fmt.Errorf("Unknown package manager for this distro")
+	}
+
+	return img, pkgmanager, nil
 }


### PR DESCRIPTION
**Add --apt to use Ubuntu containers**

This way if config.json is configured to be something different than
apt, (so the default container _isn't_ Ubuntu), Ubuntu can still be used
as container

**Reduce the config file to the bare minimum and make it optional**

Now Ubuntu is an option in the code itself, there is no need to specify
it's commands in the config file any more. Thus we can reduce it to just
a container_name, the image to use and the package manager to use for
that image.

The config file is now also completely optional. If it isn't configured
(either by a distribution package or by the user itself) apx will try to
detect the config values from the host system. If it's an unsupported
setup (e.g. no known package manager) then it'll error out and instruct
the user to setup a config file.



These changes together should make apx default to Ubuntu containers on Ubuntu, Arch containers on Arch, Fedora containers on Fedora and Alpine containers on Alpine, while still having the option to use Ubuntu containers if wanted.