### PR TITLE
feat: automatic environment variable matching to flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /debian/files
 /debian/apx.substvars
 /obj-x86_64-linux-gnu
+.envrc
+apx

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/vanilla-os/apx/core"
 )
 
@@ -43,11 +44,21 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.AddCommand(NewUnexportCommand())
 	rootCmd.AddCommand(NewUpdateCommand())
 	rootCmd.AddCommand(NewUpgradeCommand())
+	viper.BindPFlag("aur", rootCmd.PersistentFlags().Lookup("aur"))
+	viper.BindPFlag("apt", rootCmd.PersistentFlags().Lookup("apt"))
+	viper.BindPFlag("dnf", rootCmd.PersistentFlags().Lookup("dnf"))
+	viper.BindPFlag("apk", rootCmd.PersistentFlags().Lookup("apk"))
 	return rootCmd
 }
 
 func getContainer() *core.Container {
 	var kind core.ContainerType = core.APT
+	// in the future these should be moved to
+	// constants, and wrapped in package level calls
+	apt = viper.GetBool("apt")
+	aur = viper.GetBool("aur")
+	dnf = viper.GetBool("dnf")
+	apk = viper.GetBool("apk")
 	if aur {
 		kind = core.AUR
 	} else if dnf {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/vanilla-os/apx/cmd"
 )
 
@@ -23,6 +24,8 @@ var (
 func init() {
 	log.SetPrefix("\033[1m\033[34m⌬ Apx :: \033[0m")
 	log.SetFlags(0)
+	viper.SetEnvPrefix("apx") // will be uppercased automatically
+	viper.AutomaticEnv()
 }
 
 func help(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
If applied, this patch will automatically set viper flag values to matching environment variables when they have the `APX_` prefix.

ex: 
`APX_AUR=true apx list` will run apx list in the arch container without specifying the --aur flag manually.

Perfect when used in combination with `direnv` to use a specific container for a specific project directory.

requires flag values be read using viper.GetXX().