### PR TITLE
Better connection check

### DIFF
--- a/core/connection.go
+++ b/core/connection.go
@@ -16,9 +16,7 @@ import (
 
 func CheckConnection(host, port string) bool {
 	testDomain := fmt.Sprintf("%s:%s", host, port)
-	conn, err := net.Dial("tcp", testDomain)
-
-	defer conn.Close()
+	_, err := net.Dial("tcp", testDomain)
 
 	return err == nil
 }

--- a/core/connection.go
+++ b/core/connection.go
@@ -10,10 +10,15 @@ package core
 */
 
 import (
-	"net/http"
+	"fmt"
+	"net"
 )
 
-func CheckConnection() bool {
-	_, err := http.Get("https://google.com") // TODO: use a better way to check connection
+func CheckConnection(host, port string) bool {
+	testDomain := fmt.Sprintf("%s:%s", host, port)
+	conn, err := net.Dial("tcp", testDomain)
+
+	defer conn.Close()
+
 	return err == nil
 }

--- a/core/container.go
+++ b/core/container.go
@@ -187,7 +187,7 @@ func (c *Container) Enter() error {
 func (c *Container) Create() error {
 	ExitIfOverlayTypeFS()
 
-	if !CheckConnection("docker.io", "443") {
+	if !CheckConnection("cloudflare.com", "443") {
 		log.Default().Println("No internet connection. Please connect to the internet and try again.")
 		return errors.New("failed to create container")
 	}

--- a/core/container.go
+++ b/core/container.go
@@ -187,7 +187,7 @@ func (c *Container) Enter() error {
 func (c *Container) Create() error {
 	ExitIfOverlayTypeFS()
 
-	if !CheckConnection() {
+	if !CheckConnection("docker.io", "443") {
 		log.Default().Println("No internet connection. Please connect to the internet and try again.")
 		return errors.New("failed to create container")
 	}


### PR DESCRIPTION
This pull request aims to improve the way that internet connection is checked by APX in order to be simpler, faster and lighter. The simple switch from `http.Get()` to `net.Dial()` actually improved the speed of the internet connection check in **~8-10x** while internet is `CONNECTED`, and **~1.5-1.15x** the speed when it's `DISCONNECTED`.

I also implemented two parameters to the function, `host` and `port` to provide an simple way to select more suitable test servers in different areas of the code and their needs. For example, the actual single implementation of `CheckConnection()` in the current state of APX is used to check internet connection before accessing `docker.io`. So, I also pointed the test server to their domain instead of `google.com`.

All tests below were made in my own machine, using Go's native benchmark system and the requests were pointing to the google's domain: `google.com`. Check the results:

### **CONNECTION IS ONLINE**

- `net.Dial()` => 29.2ms per operation
- `http.Get()` => 233ms per operation

```
goos: linux
goarch: amd64
pkg: github.com/vanilla-os/apx
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkConnCheck-16                 36          29229155 ns/op
BenchmarkOldCheck-16                   5         233092528 ns/op
PASS
ok      github.com/vanilla-os/apx       4.099s
```

### **CONNECTION IS OFFLINE:**

- `net.Dial()` => ~0.07ms per operation
- `http.Get()` => ~0.08ms per operation

```
goos: linux
goarch: amd64
pkg: github.com/vanilla-os/apx
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkConnCheck-16              17246             70207 ns/op
BenchmarkOldCheck-16               14638             81232 ns/op
PASS
ok      github.com/vanilla-os/apx       3.937s
