### PR TITLE
Move distro definition to a struct and change pkgmanager flags for distro flags

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,6 @@
 {
-    "containername": "apx_managed",
+    "distroid": "ubuntu",
+    "containername": "apx_managed_ubuntu",
     "image": "docker.io/library/ubuntu",
     "pkgmanager": "apt",
     "distroboxpath": "/usr/lib/apx/distrobox"

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -16,42 +16,21 @@ import (
 )
 
 func (c *Container) GetPkgCommand(command string) []string {
-	switch c.containerType {
-	case APT:
+	switch c.containerType.Pkgmanager {
+	case settings.Apt:
 		return GetAptPkgCommand(command)
-	case AUR:
+	case settings.Yay:
 		return GetAurPkgCommand(command)
-	case DNF:
+	case settings.Dnf:
 		return GetDnfPkgCommand(command)
-	case APK:
+	case settings.Apk:
 		return GetApkPkgCommand(command)
-	case ZYPPER:
+	case settings.Zypper:
 		return GetZypperPkgCommand(command)
-	case XBPS:
+	case settings.Xbps:
 		return GetXbpsPkgCommand(command)
 	default:
 		return nil
-	}
-}
-
-func GetDefaultPkgCommand(command string) []string {
-	pkgmanager := settings.Cnf.PkgManager
-
-	switch pkgmanager {
-	case "apt":
-		return GetAptPkgCommand(command)
-	case "aur":
-		return GetAurPkgCommand(command)
-	case "dnf":
-		return GetDnfPkgCommand(command)
-	case "apk":
-		return GetApkPkgCommand(command)
-	case "zypper":
-		return GetZypperPkgCommand(command)
-	case "xbps":
-		return GetXbpsPkgCommand(command)
-	default:
-		return []string{"echo", pkgmanager + " is not implemented yet!"}
 	}
 }
 
@@ -242,18 +221,18 @@ func GetXbpsPkgCommand(command string) []string {
 
 func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 	var query_cmd string
-	switch c.containerType {
-	case APT:
+	switch c.containerType.Pkgmanager {
+	case settings.Apt:
 		query_cmd = "dpkg -s"
-	case AUR:
+	case settings.Yay:
 		query_cmd = "yay -Qi"
-	case DNF:
+	case settings.Dnf:
 		query_cmd = "rpm -q"
-	case APK:
+	case settings.Apk:
 		query_cmd = "apk -e info"
-	case ZYPPER:
+	case settings.Zypper:
 		query_cmd = "rpm -q"
-	case XBPS:
+	case settings.Xbps:
 		query_cmd = "xbps-query"
 	default:
 		return false, errors.New("Cannot query package from unknown container")

--- a/main.go
+++ b/main.go
@@ -9,10 +9,8 @@ package main
 */
 
 import (
-	"fmt"
 	"log"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vanilla-os/apx/cmd"
 )
@@ -26,43 +24,6 @@ func init() {
 	log.SetFlags(0)
 	viper.SetEnvPrefix("apx") // will be uppercased automatically
 	viper.AutomaticEnv()
-}
-
-func help(cmd *cobra.Command, args []string) {
-	fmt.Println(`Usage:
-  apx [command]
-
-Available Commands:
-  autoremove  Remove all unused packages automatically
-  clean       Clean the apx package manager cache
-  completion  Generate the autocompletion script for the specified shell
-  enter       Enter in the container shell
-  export      Export/Recreate a program's desktop entry from a managed container
-  help        Help about any command
-  init        Initialize the managed container
-  install     Install packages inside a managed container
-  list        List installed packages.
-  purge       Purge packages inside a managed container
-  remove      Remove packages inside a managed container.
-  run         Run a program inside a managed container.
-  search      Search for packages in a managed container.
-  show        Show details about a package
-  unexport    Unexport/Remove a program's desktop entry from a managed container
-  update      Update the list of available packages
-  upgrade     Upgrade the system by installing/upgrading available packages.
-
-Global Flags:
-      --apk           Install packages from the Alpine repository.
-      --apt           Install packages from the Ubuntu repository.
-      --aur           Install packages from the AUR (Arch User Repository).
-      --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the openSUSE repository.
-      --xbps          Install packages from the Void (Linux) repository.
-  -h, --help          help for apx
-  -n, --name string   Create or use custom container with this name.
-  -v, --version       version for apx
-
-Use "apx [command] --help" for more information about a command.`)
 }
 
 func main() {

--- a/man/apx.1
+++ b/man/apx.1
@@ -45,12 +45,17 @@ Available Commands:
   upgrade     Upgrade the system by installing/upgrading available packages.
 
 Global Flags:
-      --apk           Install packages from the Alpine repository.
-      --apt           Install packages from the Ubuntu repository.
-      --aur           Install packages from the AUR (Arch User Repository).
-      --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the OpenSUSE repository.
-      --xbps          Install packages from the Void (Linux) repository.
+      --ubuntu    Install packages from the Ubuntu repository
+      --apt       (Deprecated) Install packages from the Ubuntu repository
+      --aur       Install packages from the AUR repository
+      --fedora    Install packages from the Fedora repository
+      --dnf       (Deprecated) Install packages from the Fedora repository
+      --alpine    Install packages from the Alpine repository
+      --apk       (Deprecated) Install packages from the Alpine repository
+      --opensuse  Install packages from the OpenSUSE repository
+      --zypper    (Deprecated) Install packages from the OpenSUSE repository.
+      --void      Install packages from the Void Linux repository
+      --xbps      (Deprecated) Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/settings/distros.go
+++ b/settings/distros.go
@@ -1,0 +1,26 @@
+package settings
+
+type PackageManager string
+
+const (
+	Apt    = "apt"
+	Yay    = "yay"
+	Dnf    = "dnf"
+	Apk    = "apk"
+	Zypper = "zypper"
+	Xbps   = "xbps"
+)
+
+type DistroInfo struct {
+	Id            string
+	Image         string
+	Pkgmanager    PackageManager
+	ContainerName string
+}
+
+var DistroUbuntu = DistroInfo{Id: "ubuntu", Image: "docker.io/library/ubuntu", Pkgmanager: Apt, ContainerName: "apx_managed_ubuntu"}
+var DistroArch = DistroInfo{Id: "arch", Image: "docker.io/library/archlinux", Pkgmanager: Yay, ContainerName: "apx_managed_archlinux"}
+var DistroFedora = DistroInfo{Id: "fedora", Image: "docker.io/library/fedora", Pkgmanager: Dnf, ContainerName: "apx_managed_fedora"}
+var DistroAlpine = DistroInfo{Id: "alpine", Image: "docker.io/library/alpine", Pkgmanager: Apk, ContainerName: "apx_managed_alpine"}
+var DistroOpensuse = DistroInfo{Id: "alpine", Image: "registry.opensuse.org/opensuse/tumbleweed:latest", Pkgmanager: Zypper, ContainerName: "apx_managed_opensuse"}
+var DistroVoid = DistroInfo{Id: "alpine", Image: "ghcr.io/void-linux/void-linux:latest-full-x86_64", Pkgmanager: Xbps, ContainerName: "apx_managed_void"}


### PR DESCRIPTION
Distro definition is now a single struct with all relevant info for that distribution in a single place. When new distributions are now added as built-in sources, they only have to be specified in core/distros.go and as a commandline flag.

This also makes it possible to use more containers than just the built-in supported ones, as long as the package manager used in that container is a supported one. E.g. a Debian container can now be used by specifying it in the config file.

Aside from that the package manager flags for commands are replaced for distribution flags. For the end user the package manager used internally isn't interesting, the source of the installed package however is. So --ubuntu is more relevant than --apt, which could mean either Ubuntu, Debian, or some other apt using distro.


This is a bigger PR than my previous ones, please review and test it well!