### PR TITLE
Export binary option

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -9,6 +9,8 @@ package cmd
 */
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -19,11 +21,17 @@ func NewExportCommand() *cobra.Command {
 		Short:   "Export/Recreate a program's desktop entry from a managed container",
 		RunE:    export,
 	}
+	cmd.Flags().String("bin", "", "Export a binary instead.")
 	return cmd
 }
 
 func export(cmd *cobra.Command, args []string) error {
-
-	container.ExportDesktopEntry(args[0])
+	if cmd.Flag("bin").Value.String() != "" {
+        if err := container.ExportBinary(cmd.Flag("bin").Value.String()); err != nil {
+            fmt.Printf("Error: %s\n", err)
+        }
+	} else {
+		container.ExportDesktopEntry(args[0])
+	}
 	return nil
 }

--- a/core/container.go
+++ b/core/container.go
@@ -135,14 +135,14 @@ func GetDistroboxVersion() (version string, err error) {
 	return splitted[1], nil
 }
 
-func (c *Container) Run(args ...string) error {
+func (c *Container) Exec(capture_output bool, args ...string) (string, error) {
 	ExitIfOverlayTypeFS()
 
 	if !c.Exists() {
 		err := c.Create()
 		if err != nil {
 			log.Default().Println("Failed to initialize the container. Try manually with `apx init`.")
-			return err
+			return "", err
 		}
 	}
 
@@ -151,11 +151,34 @@ func (c *Container) Run(args ...string) error {
 	cmd := exec.Command("/usr/lib/apx/distrobox", "enter", container_name, "--")
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Env = os.Environ()
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
 
-	return cmd.Run()
+	if capture_output {
+		out, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+
+		return string(out), nil
+	} else {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+
+		return "", cmd.Run()
+	}
+}
+
+// Run executes a command with args inside the container, piping stdout, stderr,
+// and stdin to the shell.
+func (c *Container) Run(args ...string) error {
+	_, err := c.Exec(false, args...)
+	return err
+}
+
+// Output executes a command with args insinde the container, capturing and
+// returning the output
+func (c *Container) Output(args ...string) (string, error) {
+	return c.Exec(true, args...)
 }
 
 func (c *Container) Enter() error {
@@ -287,6 +310,77 @@ func (c *Container) Remove() error {
 
 func (c *Container) ExportDesktopEntry(program string) {
 	c.Run("sh", "-c", "distrobox-export --app "+program+" 2>/dev/null || true")
+}
+
+func (c *Container) ExportBinary(bin string) error {
+	// Get host's $PATH
+	out, err := c.Output("sh", "-c", "distrobox-host-exec printenv | grep PATH")
+	if err != nil {
+		return err
+	}
+
+	// If bin name not in $PATH, export to .local/bin
+	// Otherwise, export with suffix based on container name
+	if !strings.HasPrefix(out, "PATH=") {
+		return errors.New("Failed to read host's $PATH")
+	}
+	_, host_path, _ := strings.Cut(out, "=")
+
+	paths := strings.Split(host_path, ":")
+	bin_rename := ""
+	for _, path := range paths {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return err
+		}
+
+		duplicate_found := false
+		for _, entry := range entries {
+			if entry.Name() == bin {
+				switch c.containerType {
+				case APT:
+					bin_rename = fmt.Sprintf("apt_%s", bin)
+				case AUR:
+					bin_rename = fmt.Sprintf("aur_%s", bin)
+				case DNF:
+					bin_rename = fmt.Sprintf("dnf_%s", bin)
+				case APK:
+					bin_rename = fmt.Sprintf("apk_%s", bin)
+				default:
+					return errors.New("can't export binary from unknown container")
+				}
+
+				fmt.Printf("Warning: another program with name `%s` already exists on host, exporting as `%s`.\n", bin, bin_rename)
+				duplicate_found = true
+				break
+			}
+		}
+
+		// No need to keep searching if we alrady found a duplicate name
+		if duplicate_found {
+			break
+		}
+	}
+
+	bin_path_cmd := exec.Command("sh", "-c", "command -v "+bin)
+	bin_path, err := bin_path_cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	c.Run("sh", "-c", "distrobox-export --bin "+string(bin_path)+" -export-path ~/.local/bin 2>/dev/null || true")
+	if bin_rename != "" {
+		rename_cmd := exec.Command("mv", "~/.local/bin/"+bin, "~/.local/bin/"+bin_rename)
+		if err := rename_cmd.Run(); err != nil {
+			return err
+		}
+
+		fmt.Printf("Binary exported to `~/.local/bin/%s`.\n", bin_rename)
+		return nil
+	}
+
+	fmt.Printf("Binary exported to `~/.local/bin/%s`.\n", bin)
+	return nil
 }
 
 func (c *Container) RemoveDesktopEntry(program string) error {


### PR DESCRIPTION
Adds `--bin=[binary_name]` option to `apx export`, to allow exporting a binary from a container to the host system.

A shell script created using `distrobox-export` will be placed at `~/.local/bin` with the same name as the binary, unless a command with the same name already exists in the host's $PATH. If that is the case, it will export with a prefix relative to the container (e.g. apt_[bin] for apx_managed, aur_[bin] for Arch, etc).