### PR TITLE
Move distrobox path to config.json

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,6 @@
 {
     "containername": "apx_managed",
     "image": "docker.io/library/ubuntu",
-    "pkgmanager": "apt"
+    "pkgmanager": "apt",
+    "distroboxpath": "/usr/lib/apx/distrobox"
 }

--- a/core/container.go
+++ b/core/container.go
@@ -122,7 +122,7 @@ func GetHostImage() (img string, err error) {
 }
 
 func GetDistroboxVersion() (version string, err error) {
-	output, err := exec.Command("/usr/lib/apx/distrobox", "version").Output()
+	output, err := exec.Command(settings.Cnf.DistroboxPath, "version").Output()
 	if err != nil {
 		return "", err
 	}
@@ -148,7 +148,7 @@ func (c *Container) Run(args ...string) error {
 
 	container_name := c.GetContainerName()
 
-	cmd := exec.Command("/usr/lib/apx/distrobox", "enter", container_name, "--")
+	cmd := exec.Command(settings.Cnf.DistroboxPath, "enter", container_name, "--")
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
@@ -168,7 +168,7 @@ func (c *Container) Enter() error {
 
 	container_name := c.GetContainerName()
 
-	cmd := exec.Command("/usr/lib/apx/distrobox", "enter", container_name)
+	cmd := exec.Command(settings.Cnf.DistroboxPath, "enter", container_name)
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -203,7 +203,7 @@ func (c *Container) Create() error {
 
 	spinner.Start()
 
-	cmd := exec.Command("/usr/lib/apx/distrobox", "create",
+	cmd := exec.Command(settings.Cnf.DistroboxPath, "create",
 		"--name", container_name,
 		"--image", container_image,
 		"--yes",
@@ -243,7 +243,7 @@ func (c *Container) Stop() error {
 
 	spinner.Start()
 
-	cmd := exec.Command("/usr/lib/apx/distrobox", "stop", container_name, "--yes")
+	cmd := exec.Command(settings.Cnf.DistroboxPath, "stop", container_name, "--yes")
 	_, err := cmd.Output()
 
 	spinner.Stop()
@@ -275,7 +275,7 @@ func (c *Container) Remove() error {
 
 	spinner.Start()
 
-	cmd := exec.Command("/usr/lib/apx/distrobox", "rm", container_name, "--yes")
+	cmd := exec.Command(settings.Cnf.DistroboxPath, "rm", container_name, "--yes")
 	_, err = cmd.Output()
 
 	spinner.Stop()

--- a/core/essentials.go
+++ b/core/essentials.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/vanilla-os/apx/settings"
 )
 
 func init() {
@@ -28,7 +30,7 @@ Please refer to our documentation at https://documentation.vanillaos.org/`)
 }
 
 func CheckContainerTools() error {
-	_, distrobox := os.Stat("/usr/bin/distrobox")
+	_, distrobox := os.Stat(settings.Cnf.DistroboxPath)
 	docker := exec.Command("which", "docker")
 	podman := exec.Command("which", "podman")
 

--- a/core/essentials.go
+++ b/core/essentials.go
@@ -28,7 +28,7 @@ Please refer to our documentation at https://documentation.vanillaos.org/`)
 }
 
 func CheckContainerTools() error {
-	_, distrobox := os.Stat("/usr/lib/apx/distrobox")
+	_, distrobox := os.Stat("/usr/bin/distrobox")
 	docker := exec.Command("which", "docker")
 	podman := exec.Command("which", "podman")
 

--- a/settings/config.go
+++ b/settings/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ContainerName string `json:"containername"`
 	Image         string `json:"image"`
 	PkgManager    string `json:"pkgmanager"`
+	DistroboxPath string `json:"distroboxpath"`
 }
 
 var Cnf *Config
@@ -41,7 +42,7 @@ func init() {
 			log.Fatal("Unsupported setup detected, set a default distro and package manager in the config file")
 		}
 
-		Cnf = &Config{ContainerName: "apx_managed", Image: image, PkgManager: pkgmanager}
+		Cnf = &Config{ContainerName: "apx_managed", Image: image, PkgManager: pkgmanager, DistroboxPath: "/usr/lib/apx/distrobox"}
 	} else {
 		err = viper.Unmarshal(&Cnf)
 


### PR DESCRIPTION
Since apx is just a wrapper around distrobox, it could be used on other distros as well. With this modification it works perfectly on Arch, by changing the `distroboxpath` in `config.json` to `/usr/bin/distrobox`.

I could probably also work on NixOS with the correct path, but I haven't tested it yet.