### PR TITLE
Move package managers to globals and respect config.json defaults

### DIFF
--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -23,24 +23,24 @@ func (c *Container) GetPkgCommand(command string) []string {
 	case APK:
 		return GetApkPkgCommand(command)
 	default:
-		return nil
+		return GetDefaultPkgCommand(command)
 	}
 }
 
 func GetDefaultPkgCommand(command string) []string {
-	pkgmanager := settings.Cnf.PkgManager
+	pkgmanager := ContainerType(settings.Cnf.PkgManager)
 
 	switch pkgmanager {
-	case "apt":
+	case APT:
 		return GetAptPkgCommand(command)
-	case "aur":
+	case AUR:
 		return GetAurPkgCommand(command)
-	case "dnf":
+	case DNF:
 		return GetDnfPkgCommand(command)
-	case "apk":
+	case APK:
 		return GetApkPkgCommand(command)
 	default:
-		return []string{"echo", pkgmanager + " is not implemented yet!"}
+		return []string{"echo", string(pkgmanager) + " is not implemented yet!"}
 	}
 }
 

--- a/settings/config.go
+++ b/settings/config.go
@@ -29,8 +29,8 @@ type Config struct {
 var Cnf *Config
 
 func init() {
-	viper.AddConfigPath("/etc/apx/")
 	viper.AddConfigPath("config/")
+	viper.AddConfigPath("/etc/apx/")
 	viper.SetConfigName("config")
 	viper.SetConfigType("json")
 	err := viper.ReadInConfig()


### PR DESCRIPTION
- Switched `ContainerType` from `int` to `string`
- Changed the references to package managers/container names to globals and config values
- Fixed `containername` not being respected
- Fixed `image` and `pkgmanager` only working for Ubuntu
- Fixed `GetDefaultPkgCommand` not being used
- Moved image URLs to globals

