### PR TITLE
Switches to random container names + Implements labels and migration scripts

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/apx/core"
@@ -46,7 +47,6 @@ func migrate(cmd *cobra.Command, args []string) error {
 		name := string(output[2 : len(output)-2])
 
 		cmd_args := []string{
-			"-c", settings.Cnf.DistroboxPath,
 			"create",
 			"--clone", id,
 			"--name", container.GenerateNewContainerName(),
@@ -74,10 +74,10 @@ func migrate(cmd *cobra.Command, args []string) error {
 		}
 
 		cmd_args = append(cmd_args, "--additional-flags")
-		cmd_args = append(cmd_args, labels.ToArguments()...)
+		cmd_args = append(cmd_args, strings.Join(labels.ToArguments(), " "))
 		fmt.Println(cmd_args)
 
-		out, err = exec.Command("sh", cmd_args...).Output()
+		out, err = exec.Command(settings.Cnf.DistroboxPath, cmd_args...).Output()
 		if err != nil {
 			log.Fatal(string(out))
 		}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,33 @@
+package cmd
+
+/*	License: GPLv3
+	Authors:
+		Mirko Brombin <send@mirko.pm>
+		Pietro di Caprio <pietro@fabricators.ltd>
+	Copyright: 2023
+	Description: Apx is a wrapper around multiple package managers to install packages and run commands inside a managed container.
+*/
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/vanilla-os/apx/core"
+)
+
+func NewMigrateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Example: "apx migrate",
+		Use:     "migrate",
+		Short:   "Migrate legacy containers to newer format",
+		RunE:    migrate,
+	}
+	return cmd
+}
+
+func migrate(cmd *cobra.Command, args []string) error {
+	legacy_containers_ids := core.GetLegacyContainersIds()
+	fmt.Println(legacy_containers_ids)
+
+	return nil
+}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -63,6 +63,9 @@ func migrate(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		labels.Id = randstr.Hex(10)
+		labels.MigratedFrom = name
+
 		if !found {
 			// TODO Implement migration for named containers
 			log.Fatal(

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -11,7 +11,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -52,18 +51,14 @@ func migrate(cmd *cobra.Command, args []string) error {
 			"--name", container.GenerateNewContainerName(),
 		}
 
-		labels := core.ContainerLabels{
-			Managed: true,
-			Userid:  os.Geteuid(),
-		}
+		labels := &core.ContainerLabels{}
 
 		found := false
 		for _, pm := range []string{"apt", "aur", "dnf", "apk"} {
 			legacy_name, distro := core.GetLegacyContainerNameAndDistro(pm)
 			if name == legacy_name {
 				found = true
-				labels.PkgManager = settings.PackageManager(pm)
-				labels.Distro = distro
+				labels = core.CreateLabels(distro, settings.PackageManager(pm), "")
 				break
 			}
 		}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -55,17 +55,19 @@ func migrate(cmd *cobra.Command, args []string) error {
 
 		found := false
 		for _, pm := range []string{"apt", "aur", "dnf", "apk"} {
-			legacy_name, distro := core.GetLegacyContainerNameAndDistro(pm)
+			legacy_name, distro := container.GetLegacyContainerNameAndDistro(pm)
 			if name == legacy_name {
 				found = true
-				labels = core.CreateLabels(distro, settings.PackageManager(pm), "")
+				labels = core.CreateLabels(distro, settings.PackageManager(pm), container.GetCustomName())
 				break
 			}
 		}
 
 		if !found {
 			// TODO Implement migration for named containers
-			log.Fatal("Unknown container type for container: " + name)
+			log.Fatal(
+				"Unknown container type for container: " + name + "\n" +
+					"If you have named containers, try running `apx migrate --name string` for each named container")
 		}
 
 		cmd_args = append(cmd_args, "--additional-flags")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vanilla-os/apx/core"
@@ -14,12 +16,22 @@ var apt, aur, dnf, apk bool
 var container *core.Container
 var name string
 
+func checkForLegacyContainers() {
+	if len(core.GetLegacyContainersIds()) > 0 {
+		log.Fatal("Legacy containers have been detected. Please close all open apx applications and run 'apx migrate'")
+	}
+}
+
 func NewApxCommand(Version string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "apx",
 		Short:   "Apx is a package manager with support for multiple sources allowing you to install packages in a managed container.",
 		Version: Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cmd.Use != "migrate" {
+				checkForLegacyContainers()
+			}
+
 			container = getContainer()
 		},
 	}
@@ -44,6 +56,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.AddCommand(NewUnexportCommand())
 	rootCmd.AddCommand(NewUpdateCommand())
 	rootCmd.AddCommand(NewUpgradeCommand())
+	rootCmd.AddCommand(NewMigrateCommand())
 	viper.BindPFlag("aur", rootCmd.PersistentFlags().Lookup("aur"))
 	viper.BindPFlag("apt", rootCmd.PersistentFlags().Lookup("apt"))
 	viper.BindPFlag("dnf", rootCmd.PersistentFlags().Lookup("dnf"))

--- a/core/container.go
+++ b/core/container.go
@@ -41,6 +41,7 @@ type Container struct {
 func NewContainer(kind ContainerType) *Container {
 	return &Container{
 		containerType: kind,
+		customName:    "",
 	}
 }
 func NewNamedContainer(kind ContainerType, name string) *Container {
@@ -232,6 +233,7 @@ func (c *Container) Create() error {
 		Distro:     info.Id,
 		PkgManager: info.Pkgmanager,
 		Userid:     os.Geteuid(),
+		CustomName: c.customName,
 	}
 
 	cmd_args := []string{

--- a/core/container.go
+++ b/core/container.go
@@ -259,13 +259,8 @@ func (c *Container) Create() error {
 		log.Fatalf("error creating container: %v", err)
 	}
 
-	labels := ContainerLabels{
-		Managed:    true,
-		Distro:     info.Id,
-		PkgManager: info.Pkgmanager,
-		Userid:     os.Geteuid(),
-		CustomName: c.customName,
-	}
+	labels := CreateLabels(info.Id, info.Pkgmanager, c.customName)
+	labels.Id = randstr.Hex(10)
 
 	cmd_args := []string{
 		"create",

--- a/core/container.go
+++ b/core/container.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/thanhpk/randstr"
 	"github.com/vanilla-os/apx/settings"
 )
 
@@ -65,24 +66,15 @@ func (c *Container) GetContainerImage() (image string, err error) {
 	return image, err
 }
 
-func (c *Container) GetContainerName() (name string) {
+func (c *Container) GenerateNewContainerName() (name string) {
 	var cn strings.Builder
-	switch c.containerType {
-	case APT:
-		cn.WriteString("apx_managed")
-	case AUR:
-		cn.WriteString("apx_managed_aur")
-	case DNF:
-		cn.WriteString("apx_managed_dnf")
-	case APK:
-		cn.WriteString("apx_managed_apk")
-	default:
-		log.Fatal(fmt.Errorf("unspecified container type"))
-	}
+	cn.WriteString(settings.Cnf.ContainerName)
 	if len(c.customName) > 0 {
 		cn.WriteString("_")
 		cn.WriteString(strings.Replace(c.customName, " ", "", -1))
 	}
+	cn.WriteString("_")
+	cn.WriteString(randstr.Hex(10))
 	return cn.String()
 }
 
@@ -146,7 +138,8 @@ func (c *Container) Exec(capture_output bool, args ...string) (string, error) {
 		}
 	}
 
-	container_name := c.GetContainerName()
+	// container_name := c.GetContainerName()
+	container_name := "TODO_REPLACE"
 
 	cmd := exec.Command(settings.Cnf.DistroboxPath, "enter", container_name, "--")
 	cmd.Args = append(cmd.Args, args...)
@@ -189,7 +182,8 @@ func (c *Container) Enter() error {
 		return errors.New("managed container does not exist")
 	}
 
-	container_name := c.GetContainerName()
+	// container_name := c.GetContainerName()
+	container_name := "TODO_REPLACE"
 
 	cmd := exec.Command(settings.Cnf.DistroboxPath, "enter", container_name)
 	cmd.Env = os.Environ()
@@ -222,7 +216,7 @@ func (c *Container) Create() error {
 		return err
 	}
 
-	container_name := c.GetContainerName()
+	container_name := c.GenerateNewContainerName()
 	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spinner.Suffix = " Creating container..."
 
@@ -280,7 +274,8 @@ func (c *Container) Create() error {
 func (c *Container) Stop() error {
 	ExitIfOverlayTypeFS()
 
-	container_name := c.GetContainerName()
+	// container_name := c.GetContainerName()
+	container_name := "TODO_REPLACE"
 	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spinner.Suffix = " Stopping container..."
 
@@ -303,7 +298,8 @@ func (c *Container) Stop() error {
 func (c *Container) Remove() error {
 	ExitIfOverlayTypeFS()
 
-	container_name := c.GetContainerName()
+	// container_name := c.GetContainerName()
+	container_name := "TODO_REPLACE"
 	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spinner.Suffix = " Removing container..."
 
@@ -415,7 +411,8 @@ func (c *Container) ExportBinary(bin string) error {
 }
 
 func (c *Container) RemoveDesktopEntry(program string) error {
-	container_name := c.GetContainerName()
+	// container_name := c.GetContainerName()
+	container_name := "TODO_REPLACE"
 	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spinner.Suffix = fmt.Sprintf("Removing desktop entry: %v\n", program)
 
@@ -449,7 +446,8 @@ func (c *Container) RemoveDesktopEntry(program string) error {
 }
 
 func (c *Container) Exists() bool {
-	container_name := c.GetContainerName()
+	// container_name := c.GetContainerName()
+	container_name := "TODO_REPLACE"
 	manager := ContainerManager()
 
 	cmd := exec.Command(manager, "ps", "-a", "-q", "-f", "name="+container_name+"$")

--- a/core/container.go
+++ b/core/container.go
@@ -67,6 +67,10 @@ func (c *Container) GetContainerImage() (image string, err error) {
 	return image, err
 }
 
+func (c *Container) GetCustomName() string {
+	return c.customName
+}
+
 func (c *Container) GenerateNewContainerName() (name string) {
 	var cn strings.Builder
 	cn.WriteString(settings.Cnf.ContainerName)

--- a/core/labels.go
+++ b/core/labels.go
@@ -34,3 +34,13 @@ func (l *ContainerLabels) ToArguments() []string {
 		"--label=apx.customname=" + l.CustomName,
 	}
 }
+
+func (l *ContainerLabels) ToFilters() []string {
+	return []string{
+		"--filter", "label=apx.managed=" + fmt.Sprint(l.Managed),
+		"--filter", "label=apx.distro=" + l.Distro,
+		"--filter", "label=apx.pkgmanager=" + string(l.PkgManager),
+		"--filter", "label=apx.userid=" + fmt.Sprint(l.Userid),
+		"--filter", "label=apx.customname=" + l.CustomName,
+	}
+}

--- a/core/labels.go
+++ b/core/labels.go
@@ -20,6 +20,6 @@ func (l *ContainerLabels) ToArguments() []string {
 		"--label=apx.distro=" + l.Distro,
 		"--label=apx.pkgmanager=" + string(l.PkgManager),
 		"--label=apx.userid=" + fmt.Sprint(l.Userid),
-		"--label=apx.customname=" + l.CustomName + "\"",
+		"--label=apx.customname=" + l.CustomName,
 	}
 }

--- a/core/labels.go
+++ b/core/labels.go
@@ -15,9 +15,9 @@ type ContainerLabels struct {
 
 func (l *ContainerLabels) ToArguments() []string {
 	return []string{
-		"--label=\"apx.managed=" + fmt.Sprint(l.Managed) + "\"",
-		"--label=\"apx.distro=" + l.Distro + "\"",
-		"--label=\"apx.pkgmanager=" + string(l.PkgManager) + "\"",
-		"--label=\"apx.userid=" + fmt.Sprint(l.Userid) + "\"",
+		"--label=apx.managed=" + fmt.Sprint(l.Managed),
+		"--label=apx.distro=" + l.Distro,
+		"--label=apx.pkgmanager=" + string(l.PkgManager),
+		"--label=apx.userid=" + fmt.Sprint(l.Userid),
 	}
 }

--- a/core/labels.go
+++ b/core/labels.go
@@ -11,6 +11,7 @@ type ContainerLabels struct {
 	Distro     string
 	PkgManager settings.PackageManager
 	Userid     int
+	CustomName string
 }
 
 func (l *ContainerLabels) ToArguments() []string {
@@ -19,5 +20,6 @@ func (l *ContainerLabels) ToArguments() []string {
 		"--label=apx.distro=" + l.Distro,
 		"--label=apx.pkgmanager=" + string(l.PkgManager),
 		"--label=apx.userid=" + fmt.Sprint(l.Userid),
+		"--label=apx.customname=" + l.CustomName + "\"",
 	}
 }

--- a/core/labels.go
+++ b/core/labels.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/vanilla-os/apx/settings"
+)
+
+type ContainerLabels struct {
+	Managed    bool
+	Distro     string
+	PkgManager settings.PackageManager
+	Userid     int
+}
+
+func (l *ContainerLabels) ToArguments() []string {
+	return []string{
+		"--label=apx.managed=" + fmt.Sprint(l.Managed),
+		"--label=apx.distro=" + l.Distro,
+		"--label=apx.pkgmanager=" + string(l.PkgManager),
+		"--label=apx.userid=" + fmt.Sprint(l.Userid),
+	}
+}

--- a/core/labels.go
+++ b/core/labels.go
@@ -8,11 +8,13 @@ import (
 )
 
 type ContainerLabels struct {
-	Managed    bool
-	Distro     string
-	PkgManager settings.PackageManager
-	Userid     int
-	CustomName string
+	Id           string
+	Managed      bool
+	Distro       string
+	PkgManager   settings.PackageManager
+	Userid       int
+	CustomName   string
+	MigratedFrom string
 }
 
 func CreateLabels(distro string, pkgManager settings.PackageManager, name string) *ContainerLabels {
@@ -27,11 +29,13 @@ func CreateLabels(distro string, pkgManager settings.PackageManager, name string
 
 func (l *ContainerLabels) ToArguments() []string {
 	return []string{
+		"--label=apx.id=" + l.Id,
 		"--label=apx.managed=" + fmt.Sprint(l.Managed),
 		"--label=apx.distro=" + l.Distro,
 		"--label=apx.pkgmanager=" + string(l.PkgManager),
 		"--label=apx.userid=" + fmt.Sprint(l.Userid),
 		"--label=apx.customname=" + l.CustomName,
+		"--label=apx.migratedfrom=" + l.MigratedFrom,
 	}
 }
 

--- a/core/labels.go
+++ b/core/labels.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/vanilla-os/apx/settings"
 )
@@ -12,6 +13,16 @@ type ContainerLabels struct {
 	PkgManager settings.PackageManager
 	Userid     int
 	CustomName string
+}
+
+func CreateLabels(distro string, pkgManager settings.PackageManager, name string) *ContainerLabels {
+	return &ContainerLabels{
+		Managed:    true,
+		Distro:     distro,
+		PkgManager: pkgManager,
+		Userid:     os.Geteuid(),
+		CustomName: name,
+	}
 }
 
 func (l *ContainerLabels) ToArguments() []string {

--- a/core/labels.go
+++ b/core/labels.go
@@ -15,9 +15,9 @@ type ContainerLabels struct {
 
 func (l *ContainerLabels) ToArguments() []string {
 	return []string{
-		"--label=apx.managed=" + fmt.Sprint(l.Managed),
-		"--label=apx.distro=" + l.Distro,
-		"--label=apx.pkgmanager=" + string(l.PkgManager),
-		"--label=apx.userid=" + fmt.Sprint(l.Userid),
+		"--label=\"apx.managed=" + fmt.Sprint(l.Managed) + "\"",
+		"--label=\"apx.distro=" + l.Distro + "\"",
+		"--label=\"apx.pkgmanager=" + string(l.PkgManager) + "\"",
+		"--label=\"apx.userid=" + fmt.Sprint(l.Userid) + "\"",
 	}
 }

--- a/core/legacy.go
+++ b/core/legacy.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+var legacy_containers_ids = []string(nil)
+
+func GetLegacyContainersIds() []string {
+	if legacy_containers_ids != nil {
+		return legacy_containers_ids
+	}
+
+	manager := ContainerManager()
+
+	cmd := exec.Command(manager, "ps", "-aqf", "label=manager=apx")
+	output, _ := cmd.Output()
+
+	containers_ids := strings.Split(string(output), "\n")
+
+	cmd = exec.Command(manager, "ps", "-aqf", "label=apx.managed="+fmt.Sprint(true))
+	output, _ = cmd.Output()
+
+	migrated_containers_ids := strings.Split(string(output), "\n")
+
+	legacy_containers_ids = []string{}
+	for _, id := range containers_ids {
+		if !slices.Contains(migrated_containers_ids, id) {
+			legacy_containers_ids = append(legacy_containers_ids, id)
+		}
+	}
+
+	return legacy_containers_ids
+}
+
+func (c *Container) GetLegacyContainerName() (name string) {
+	var cn strings.Builder
+	switch c.containerType {
+	case APT:
+		cn.WriteString("apx_managed")
+	case AUR:
+		cn.WriteString("apx_managed_aur")
+	case DNF:
+		cn.WriteString("apx_managed_dnf")
+	case APK:
+		cn.WriteString("apx_managed_apk")
+	default:
+		log.Fatal(fmt.Errorf("unspecified container type"))
+	}
+	if len(c.customName) > 0 {
+		cn.WriteString("_")
+		cn.WriteString(strings.Replace(c.customName, " ", "", -1))
+	}
+	return cn.String()
+}

--- a/core/legacy.go
+++ b/core/legacy.go
@@ -38,17 +38,31 @@ func GetLegacyContainersIds() []string {
 	return legacy_containers_ids
 }
 
-func GetLegacyContainerNameAndDistro(pkgManager string) (string, string) {
+func (c *Container) GetLegacyContainerNameAndDistro(pkgManager string) (string, string) {
+	var cn strings.Builder
+	var distro string
+
 	switch pkgManager {
 	case "apt":
-		return "apx_managed", "ubuntu"
+		cn.WriteString("apx_managed")
+		distro = "ubuntu"
 	case "aur":
-		return "apx_managed_aur", "archlinux"
+		cn.WriteString("apx_managed_aur")
+		distro = "archlinux"
 	case "dnf":
-		return "apx_managed_dnf", "fedora"
+		cn.WriteString("apx_managed_dnf")
+		distro = "fedora"
 	case "apk":
-		return "apx_managed_apk", "alpine"
+		cn.WriteString("apx_managed_apk")
+		distro = "alpine"
+	default:
+		log.Fatal(fmt.Errorf("unspecified container type"))
 	}
-	log.Fatal(fmt.Errorf("unspecified container type"))
-	return "", ""
+
+	if len(c.customName) > 0 {
+		cn.WriteString("_")
+		cn.WriteString(strings.Replace(c.customName, " ", "", -1))
+	}
+
+	return cn.String(), distro
 }

--- a/core/legacy.go
+++ b/core/legacy.go
@@ -38,23 +38,17 @@ func GetLegacyContainersIds() []string {
 	return legacy_containers_ids
 }
 
-func (c *Container) GetLegacyContainerName() (name string) {
-	var cn strings.Builder
-	switch c.containerType {
-	case APT:
-		cn.WriteString("apx_managed")
-	case AUR:
-		cn.WriteString("apx_managed_aur")
-	case DNF:
-		cn.WriteString("apx_managed_dnf")
-	case APK:
-		cn.WriteString("apx_managed_apk")
-	default:
-		log.Fatal(fmt.Errorf("unspecified container type"))
+func GetLegacyContainerNameAndDistro(pkgManager string) (string, string) {
+	switch pkgManager {
+	case "apt":
+		return "apx_managed", "ubuntu"
+	case "aur":
+		return "apx_managed_aur", "archlinux"
+	case "dnf":
+		return "apx_managed_dnf", "fedora"
+	case "apk":
+		return "apx_managed_apk", "alpine"
 	}
-	if len(c.customName) > 0 {
-		cn.WriteString("_")
-		cn.WriteString(strings.Replace(c.customName, " ", "", -1))
-	}
-	return cn.String()
+	log.Fatal(fmt.Errorf("unspecified container type"))
+	return "", ""
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	github.com/thanhpk/randstr v1.0.4 // indirect
+	golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/thanhpk/randstr v1.0.4 h1:IN78qu/bR+My+gHCvMEXhR/i5oriVHcTB/BJJIRTsNo=
+github.com/thanhpk/randstr v1.0.4/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -213,6 +215,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a h1:tlXy25amD5A7gOfbXdqCGN5k8ESEed/Ee1E5RcrYnqU=
+golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -327,6 +331,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/settings/distros.go
+++ b/settings/distros.go
@@ -1,5 +1,7 @@
 package settings
 
+import "errors"
+
 type PackageManager string
 
 const (
@@ -14,6 +16,21 @@ type DistroInfo struct {
 	Image         string
 	Pkgmanager    PackageManager
 	ContainerName string
+}
+
+func FromPackageManger(pkgmanager string) (DistroInfo, error) {
+	switch pkgmanager {
+	case Apt:
+		return DistroUbuntu, nil
+	case Yay:
+		return DistroArch, nil
+	case Dnf:
+		return DistroFedora, nil
+	case Apk:
+		return DistroAlpine, nil
+	default:
+		return DistroInfo{}, errors.New("Invalid package manager")
+	}
 }
 
 var DistroUbuntu = DistroInfo{Id: "ubuntu", Image: "docker.io/library/ubuntu", Pkgmanager: Apt, ContainerName: "apx_managed_ubuntu"}

--- a/settings/distros.go
+++ b/settings/distros.go
@@ -1,0 +1,22 @@
+package settings
+
+type PackageManager string
+
+const (
+	Apt = "apt"
+	Yay = "yay"
+	Dnf = "dnf"
+	Apk = "apk"
+)
+
+type DistroInfo struct {
+	Id            string
+	Image         string
+	Pkgmanager    PackageManager
+	ContainerName string
+}
+
+var DistroUbuntu = DistroInfo{Id: "ubuntu", Image: "docker.io/library/ubuntu", Pkgmanager: Apt, ContainerName: "apx_managed_ubuntu"}
+var DistroArch = DistroInfo{Id: "arch", Image: "docker.io/library/archlinux", Pkgmanager: Yay, ContainerName: "apx_managed_archlinux"}
+var DistroFedora = DistroInfo{Id: "fedora", Image: "docker.io/library/fedora", Pkgmanager: Dnf, ContainerName: "apx_managed_fedora"}
+var DistroAlpine = DistroInfo{Id: "alpine", Image: "docker.io/library/alpine", Pkgmanager: Apk, ContainerName: "apx_managed_alpine"}


### PR DESCRIPTION
* [x] Implement labels
	* [x] apx.managed (Boolean) -> I chose this instead of `manager=apx`, as Docker's guidelines say to use domain-name-like labels
	* [x] apx.distro (String) -> The distro that is installed in the container
	* [x] apx.pkgmanager (String) -> The package manager used in the container
	* [x] apx.userid (Integer) -> The id of the user (id -u) which is used to distinguish which container belongs to which user. I chose ids because usernames can change
	* [x] apx.customname (String) -> The name passed by the `--name` parameter
	* [x] apx.id (String) -> A unique and constant id which will stay the same, in case a future migration is required
	* [x] apx.migratedfrom (String) -> The container name of the original container, in case a migration has happened (for compatibility reasons)
* [x] Remove the distro/package manager from the containers' names
* [x] Implement the `migrate` command to clone older containers to ones with the new naming scheme
* [ ] Implement migration for exported files
	- [ ] Proper labeling, since we should rely on IDs
	- [ ] Implement `--apx-id` flag for `apx enter` (It will be used for new desktop entries)
	- [ ] Implement `--old-name` flag for `apx enter` (It will be used for older desktop entries)
	- [ ] Replace `distrobox-enter` to `apx enter` and use the either `--apx-id` or `--old-name`
	- [ ] Create an SQLite database to track exported files (could help with #32 and #64)

We will probably also need a test suite after this.

Related to #50, #60, #61