### PR TITLE
chore: update readme with vendoring information

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ The official **documentation and manpage** for `apx` are available at <https://d
 
 To use with another package manager, re-compile editing the `config.json` file
 to point to the desired package manger and image.
+
+
+## Dependencies
+
+To add new dependencies, use `go get` as usual, then run `go mod tidy` and finally `go mod vendor` before
+committing code.


### PR DESCRIPTION
If merged this PR will add documentation to the README about working with vendored go modules.