### PR TITLE
Export: don't crash when user didn't provide an application name:

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -9,6 +9,7 @@ package cmd
 */
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -31,6 +32,9 @@ func export(cmd *cobra.Command, args []string) error {
             fmt.Printf("Error: %s\n", err)
         }
 	} else {
+        if len(args) == 0 {
+            return errors.New("Please specify a program to export.")
+        }
 		container.ExportDesktopEntry(args[0])
 	}
 	return nil

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -28,13 +28,13 @@ func NewExportCommand() *cobra.Command {
 
 func export(cmd *cobra.Command, args []string) error {
 	if cmd.Flag("bin").Value.String() != "" {
-        if err := container.ExportBinary(cmd.Flag("bin").Value.String()); err != nil {
-            fmt.Printf("Error: %s\n", err)
-        }
+		if err := container.ExportBinary(cmd.Flag("bin").Value.String()); err != nil {
+			fmt.Printf("Error: %s\n", err)
+		}
 	} else {
-        if len(args) == 0 {
-            return errors.New("Please specify a program to export.")
-        }
+		if len(args) == 0 {
+			return errors.New("Please specify a program to export.")
+		}
 		container.ExportDesktopEntry(args[0])
 	}
 	return nil


### PR DESCRIPTION
If the user runs `apx export` without providing an application name, the program would just crash. This pr checks whether an argument was provided and, if not, prints a useful error message to the user.