### PR TITLE
Export bin dir fix

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -329,6 +329,12 @@ func (c *Container) ExportBinary(bin string) error {
 	}
 	_, host_path, _ := strings.Cut(out, "=")
 
+    // Ensure `~/.local/bin` exists
+    local_bin_path := fmt.Sprintf("/home/%s/.local/bin", os.Getenv("USER"))
+    if _, err := os.Stat(local_bin_path); os.IsNotExist(err) {
+        os.Mkdir(local_bin_path, 0775)
+    }
+
 	paths := strings.Split(host_path, ":")
 	bin_rename := ""
 	for _, path := range paths {

--- a/core/container.go
+++ b/core/container.go
@@ -329,11 +329,11 @@ func (c *Container) ExportBinary(bin string) error {
 	}
 	_, host_path, _ := strings.Cut(out, "=")
 
-    // Ensure `~/.local/bin` exists
-    local_bin_path := fmt.Sprintf("/home/%s/.local/bin", os.Getenv("USER"))
-    if _, err := os.Stat(local_bin_path); os.IsNotExist(err) {
-        os.Mkdir(local_bin_path, 0775)
-    }
+	// Ensure `~/.local/bin` exists
+	local_bin_path := fmt.Sprintf("/home/%s/.local/bin", os.Getenv("USER"))
+	if _, err := os.Stat(local_bin_path); os.IsNotExist(err) {
+		os.Mkdir(local_bin_path, 0775)
+	}
 
 	paths := strings.Split(host_path, ":")
 	bin_rename := ""

--- a/vendor/github.com/fsnotify/fsnotify/CHANGELOG.md
+++ b/vendor/github.com/fsnotify/fsnotify/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Linux: use InotifyInit1 with IN_CLOEXEC to stop leaking a file descriptor to a child process when using fork/exec [#178](https://github.com/fsnotify/fsnotify/pull/178) (thanks @pattyshack)
 
-## [1.4.1-1] - 2016-10-04
+## [1.4.1] - 2016-10-04
 
 * Fix flaky inotify stress test on Linux [#177](https://github.com/fsnotify/fsnotify/pull/177) (thanks @pattyshack)
 

--- a/vendor/github.com/magiconair/properties/CHANGELOG.md
+++ b/vendor/github.com/magiconair/properties/CHANGELOG.md
@@ -127,7 +127,7 @@
 
  * [Issue #2](https://github.com/magiconair/properties/issues/2): Fixed goroutine leak in parser which created two lexers but cleaned up only one
 
-### [1.4.1-1](https://github.com/magiconair/properties/tree/v1.4.1-1) - 13 Nov 2014
+### [1.4.1](https://github.com/magiconair/properties/tree/v1.4.1) - 13 Nov 2014
 
  * [Issue #1](https://github.com/magiconair/properties/issues/1): Fixed bug in Keys() method which returned an empty string
 

--- a/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
+++ b/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
@@ -21,7 +21,7 @@
   field names. [GH-250]
 * Fix possible panic in ComposeDecodeHookFunc [GH-251]
 
-## 1.4.1-1
+## 1.4.1
 
 * Fix regression where `*time.Time` value would be set to empty and not be sent
   to decode hooks properly [GH-232]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -70,7 +70,7 @@ github.com/spf13/viper/internal/encoding/javaproperties
 github.com/spf13/viper/internal/encoding/json
 github.com/spf13/viper/internal/encoding/toml
 github.com/spf13/viper/internal/encoding/yaml
-# github.com/subosito/gotenv v1.4.1-1
+# github.com/subosito/gotenv v1.4.1
 ## explicit; go 1.18
 github.com/subosito/gotenv
 # golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a


### PR DESCRIPTION
Ensures `~/.local/bin` exists before exporting a binary. Fixes `apx export --bin` silently failing due to missing directory.