### PR TITLE
Exit status on show -i

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 func NewShowCommand() *cobra.Command {
@@ -38,8 +39,10 @@ func show(cmd *cobra.Command, args []string) error {
 
 		if result {
 			fmt.Printf("%s is installed", args[0])
+			os.Exit(0)
 		} else {
 			fmt.Printf("%s is not installed", args[0])
+			os.Exit(1)
 		}
 
 		return nil


### PR DESCRIPTION
Adds exit status to `apx show -i [package]` so the gnome-software plugin doesn't have to compare whole strings to check whether the application is installed.