### PR TITLE
Add zypper, xbps (Void Linux) to apx, fix export bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the OpenSUSE's Zypper repository.
+      --zypper        Install packages from the openSUSE's Zypper repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the openSUSE repository.
+      --void          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the openSUSE's Zypper repository.
+      --zypper        Install packages from the openSUSE repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
+      --zypper        Install packages from the OpenSUSE's Zypper repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the openSUSE repository.
-      --void          Install packages from the Void (Linux) repository.
+      --xbps          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&aur, "aur", false, "Install packages from the AUR (Arch User Repository).")
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
-	rootCmd.PersistentFlags().BoolVar(&zypper, "zypper", false, " Install packages from the OpenSUSE's Zypper repository.")
+	rootCmd.PersistentFlags().BoolVar(&zypper, "zypper", false, " Install packages from the OpenSUSE repository.")
 	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create or use custom container with this name.")
 
 	rootCmd.AddCommand(NewInitializeCommand())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 // package level variables for viper flags
-var apt, aur, dnf, apk, zypper bool
+var apt, aur, dnf, apk, zypper, void bool
 
 // package level variable for container name,
 // set in root command's PersistentPreRun function
@@ -28,6 +28,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
 	rootCmd.PersistentFlags().BoolVar(&zypper, "zypper", false, " Install packages from the OpenSUSE repository.")
+	rootCmd.PersistentFlags().BoolVar(&void, "void", false, " Install packages from the Void (Linux) repository.")
 	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create or use custom container with this name.")
 
 	rootCmd.AddCommand(NewInitializeCommand())
@@ -50,6 +51,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	viper.BindPFlag("dnf", rootCmd.PersistentFlags().Lookup("dnf"))
 	viper.BindPFlag("apk", rootCmd.PersistentFlags().Lookup("apk"))
 	viper.BindPFlag("zypper", rootCmd.PersistentFlags().Lookup("zypper"))
+	viper.BindPFlag("void", rootCmd.PersistentFlags().Lookup("void"))
 	return rootCmd
 }
 
@@ -62,6 +64,7 @@ func getContainer() *core.Container {
 	dnf = viper.GetBool("dnf")
 	apk = viper.GetBool("apk")
 	zypper = viper.GetBool("zypper")
+	void = viper.GetBool("void")
 	if aur {
 		kind = core.AUR
 	} else if dnf {
@@ -70,6 +73,8 @@ func getContainer() *core.Container {
 		kind = core.APK
 	} else if zypper {
 		kind = core.ZYPPER
+	} else if void {
+		kind = core.VOID
 	}
 	if len(name) > 0 {
 		return core.NewNamedContainer(kind, name)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 // package level variables for viper flags
-var apt, aur, dnf, apk, zypper, void bool
+var apt, aur, dnf, apk, zypper, xbps bool
 
 // package level variable for container name,
 // set in root command's PersistentPreRun function
@@ -28,7 +28,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
 	rootCmd.PersistentFlags().BoolVar(&zypper, "zypper", false, " Install packages from the OpenSUSE repository.")
-	rootCmd.PersistentFlags().BoolVar(&void, "void", false, " Install packages from the Void (Linux) repository.")
+	rootCmd.PersistentFlags().BoolVar(&xbps, "xbps", false, " Install packages from the Void (Linux) repository.")
 	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create or use custom container with this name.")
 
 	rootCmd.AddCommand(NewInitializeCommand())
@@ -51,7 +51,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	viper.BindPFlag("dnf", rootCmd.PersistentFlags().Lookup("dnf"))
 	viper.BindPFlag("apk", rootCmd.PersistentFlags().Lookup("apk"))
 	viper.BindPFlag("zypper", rootCmd.PersistentFlags().Lookup("zypper"))
-	viper.BindPFlag("void", rootCmd.PersistentFlags().Lookup("void"))
+	viper.BindPFlag("xbps", rootCmd.PersistentFlags().Lookup("xbps"))
 	return rootCmd
 }
 
@@ -64,7 +64,7 @@ func getContainer() *core.Container {
 	dnf = viper.GetBool("dnf")
 	apk = viper.GetBool("apk")
 	zypper = viper.GetBool("zypper")
-	void = viper.GetBool("void")
+	xbps = viper.GetBool("xbps")
 	if aur {
 		kind = core.AUR
 	} else if dnf {
@@ -73,8 +73,8 @@ func getContainer() *core.Container {
 		kind = core.APK
 	} else if zypper {
 		kind = core.ZYPPER
-	} else if void {
-		kind = core.VOID
+	} else if xbps {
+		kind = core.XBPS
 	}
 	if len(name) > 0 {
 		return core.NewNamedContainer(kind, name)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 // package level variables for viper flags
-var apt, aur, dnf, apk bool
+var apt, aur, dnf, apk, zypper bool
 
 // package level variable for container name,
 // set in root command's PersistentPreRun function
@@ -27,6 +27,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&aur, "aur", false, "Install packages from the AUR (Arch User Repository).")
 	rootCmd.PersistentFlags().BoolVar(&dnf, "dnf", false, "Install packages from the Fedora's DNF (Dandified YUM) repository.")
 	rootCmd.PersistentFlags().BoolVar(&apk, "apk", false, "Install packages from the Alpine repository.")
+	rootCmd.PersistentFlags().BoolVar(&zypper, "zypper", false, " Install packages from the OpenSUSE's Zypper repository.")
 	rootCmd.PersistentFlags().StringVarP(&name, "name", "n", "", "Create or use custom container with this name.")
 
 	rootCmd.AddCommand(NewInitializeCommand())
@@ -48,6 +49,7 @@ func NewApxCommand(Version string) *cobra.Command {
 	viper.BindPFlag("apt", rootCmd.PersistentFlags().Lookup("apt"))
 	viper.BindPFlag("dnf", rootCmd.PersistentFlags().Lookup("dnf"))
 	viper.BindPFlag("apk", rootCmd.PersistentFlags().Lookup("apk"))
+	viper.BindPFlag("zypper", rootCmd.PersistentFlags().Lookup("zypper"))
 	return rootCmd
 }
 
@@ -59,12 +61,15 @@ func getContainer() *core.Container {
 	aur = viper.GetBool("aur")
 	dnf = viper.GetBool("dnf")
 	apk = viper.GetBool("apk")
+	zypper = viper.GetBool("zypper")
 	if aur {
 		kind = core.AUR
 	} else if dnf {
 		kind = core.DNF
 	} else if apk {
 		kind = core.APK
+	} else if zypper {
+		kind = core.ZYPPER
 	}
 	if len(name) > 0 {
 		return core.NewNamedContainer(kind, name)

--- a/core/container.go
+++ b/core/container.go
@@ -328,9 +328,9 @@ func (c *Container) ExportDesktopEntry(program string) {
 
 func (c *Container) ExportBinary(bin string) error {
 	// Get host's $PATH
-	out, err := c.Output("sh", "-c", "distrobox-host-exec $(getent passwd $USER | cut -f 7 -d :) -l -i -c printenv | grep -E ^PATH=")
+	out, err := c.Output("sh", "-c", "distrobox-host-exec $(readlink -fn $(getent passwd $USER | cut -f 7 -d :)) -l -i -c printenv | grep -E ^PATH=")
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("Failed to execute printenv: %s", err))
 	}
 
 	// If bin name not in $PATH, export to .local/bin
@@ -356,7 +356,7 @@ func (c *Container) ExportBinary(bin string) error {
 
 		entries, err := os.ReadDir(path)
 		if err != nil {
-			return err
+			return errors.New(fmt.Sprintf("Could not read directory %s: %s", path, err))
 		}
 
 		duplicate_found := false

--- a/core/container.go
+++ b/core/container.go
@@ -32,7 +32,7 @@ const (
 	DNF    ContainerType = iota // 2
 	APK    ContainerType = iota // 3
 	ZYPPER ContainerType = iota // 4
-	VOID   ContainerType = iota // 5
+	XBPS   ContainerType = iota // 5
 )
 
 type Container struct {
@@ -63,7 +63,7 @@ func (c *Container) GetContainerImage() (image string, err error) {
 		return "docker.io/library/alpine", nil
 	case ZYPPER:
 		return "registry.opensuse.org/opensuse/tumbleweed:latest", nil
-	case VOID:
+	case XBPS:
 		return "ghcr.io/void-linux/void-linux:latest-full-x86_64", nil
 	default:
 		image = ""
@@ -85,8 +85,8 @@ func (c *Container) GetContainerName() (name string) {
 		cn.WriteString("apx_managed_apk")
 	case ZYPPER:
 		cn.WriteString("apx_managed_zypper")
-	case VOID:
-		cn.WriteString("apx_managed_void")
+	case XBPS:
+		cn.WriteString("apx_managed_xbps")
 	default:
 		log.Fatal(fmt.Errorf("unspecified container type"))
 	}
@@ -374,8 +374,8 @@ func (c *Container) ExportBinary(bin string) error {
 					bin_rename = fmt.Sprintf("apk_%s", bin)
 				case ZYPPER:
 					bin_rename = fmt.Sprintf("zypper_%s", bin)
-				case VOID:
-					bin_rename = fmt.Sprintf("void_%s", bin)
+				case XBPS:
+					bin_rename = fmt.Sprintf("xbps_%s", bin)
 				default:
 					return errors.New("can't export binary from unknown container")
 				}
@@ -473,8 +473,8 @@ func (c *Container) RemoveBinary(bin string, fail_silently bool) error {
 			prefix = fmt.Sprintf("apk_%s", bin)
 		case ZYPPER:
 			prefix = fmt.Sprintf("zypper_%s", bin)
-		case VOID:
-			prefix = fmt.Sprintf("void_%s", bin)
+		case XBPS:
+			prefix = fmt.Sprintf("xbps_%s", bin)
 		default:
 			return errors.New("can't unexport binary from unknown container")
 		}

--- a/core/container.go
+++ b/core/container.go
@@ -32,6 +32,7 @@ const (
 	DNF    ContainerType = iota // 2
 	APK    ContainerType = iota // 3
 	ZYPPER ContainerType = iota // 4
+	VOID   ContainerType = iota // 5
 )
 
 type Container struct {
@@ -62,6 +63,8 @@ func (c *Container) GetContainerImage() (image string, err error) {
 		return "docker.io/library/alpine", nil
 	case ZYPPER:
 		return "registry.opensuse.org/opensuse/tumbleweed:latest", nil
+	case VOID:
+		return "ghcr.io/void-linux/void-linux:latest-full-x86_64", nil
 	default:
 		image = ""
 		err = errors.New("can't retrieve image for unknown container")
@@ -82,6 +85,8 @@ func (c *Container) GetContainerName() (name string) {
 		cn.WriteString("apx_managed_apk")
 	case ZYPPER:
 		cn.WriteString("apx_managed_zypper")
+	case VOID:
+		cn.WriteString("apx_managed_void")
 	default:
 		log.Fatal(fmt.Errorf("unspecified container type"))
 	}
@@ -369,6 +374,8 @@ func (c *Container) ExportBinary(bin string) error {
 					bin_rename = fmt.Sprintf("apk_%s", bin)
 				case ZYPPER:
 					bin_rename = fmt.Sprintf("zypper_%s", bin)
+				case VOID:
+					bin_rename = fmt.Sprintf("void_%s", bin)
 				default:
 					return errors.New("can't export binary from unknown container")
 				}
@@ -466,6 +473,8 @@ func (c *Container) RemoveBinary(bin string, fail_silently bool) error {
 			prefix = fmt.Sprintf("apk_%s", bin)
 		case ZYPPER:
 			prefix = fmt.Sprintf("zypper_%s", bin)
+		case VOID:
+			prefix = fmt.Sprintf("void_%s", bin)
 		default:
 			return errors.New("can't unexport binary from unknown container")
 		}

--- a/core/container.go
+++ b/core/container.go
@@ -27,10 +27,11 @@ import (
 type ContainerType int
 
 const (
-	APT ContainerType = iota // 0
-	AUR ContainerType = iota // 1
-	DNF ContainerType = iota // 2
-	APK ContainerType = iota // 3
+	APT    ContainerType = iota // 0
+	AUR    ContainerType = iota // 1
+	DNF    ContainerType = iota // 2
+	APK    ContainerType = iota // 3
+	ZYPPER ContainerType = iota // 4
 )
 
 type Container struct {
@@ -59,6 +60,8 @@ func (c *Container) GetContainerImage() (image string, err error) {
 		return "docker.io/library/fedora", nil
 	case APK:
 		return "docker.io/library/alpine", nil
+	case ZYPPER:
+		return "registry.opensuse.org/opensuse/tumbleweed:latest", nil
 	default:
 		image = ""
 		err = errors.New("can't retrieve image for unknown container")
@@ -77,6 +80,8 @@ func (c *Container) GetContainerName() (name string) {
 		cn.WriteString("apx_managed_dnf")
 	case APK:
 		cn.WriteString("apx_managed_apk")
+	case ZYPPER:
+		cn.WriteString("apx_managed_zypper")
 	default:
 		log.Fatal(fmt.Errorf("unspecified container type"))
 	}
@@ -362,6 +367,8 @@ func (c *Container) ExportBinary(bin string) error {
 					bin_rename = fmt.Sprintf("dnf_%s", bin)
 				case APK:
 					bin_rename = fmt.Sprintf("apk_%s", bin)
+				case ZYPPER:
+					bin_rename = fmt.Sprintf("zypper_%s", bin)
 				default:
 					return errors.New("can't export binary from unknown container")
 				}
@@ -457,6 +464,8 @@ func (c *Container) RemoveBinary(bin string, fail_silently bool) error {
 			prefix = fmt.Sprintf("dnf_%s", bin)
 		case APK:
 			prefix = fmt.Sprintf("apk_%s", bin)
+		case ZYPPER:
+			prefix = fmt.Sprintf("zypper_%s", bin)
 		default:
 			return errors.New("can't unexport binary from unknown container")
 		}

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -178,13 +178,13 @@ func GetZypperPkgCommand(command string) []string {
 
 	switch command {
 	case "autoremove":
-		return []string{"sudo", bin, "rm -u"}
+		return []string{"echo", "Not implemented yet! "}
 	case "clean":
 		return []string{"sudo", bin, "clean"}
 	case "install":
 		return []string{"sudo", bin, "install"}
 	case "list":
-		return []string{"sudo", "rpm -qa"}
+		return []string{"sudo", bin, "pa"}
 	case "purge":
 		return []string{"sudo", bin, "remove"}
 	case "remove":

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -26,6 +26,8 @@ func (c *Container) GetPkgCommand(command string) []string {
 		return GetApkPkgCommand(command)
 	case ZYPPER:
 		return GetZypperPkgCommand(command)
+	case VOID:
+		return GetVoidPkgCommand(command)
 	default:
 		return nil
 	}
@@ -45,6 +47,8 @@ func GetDefaultPkgCommand(command string) []string {
 		return GetApkPkgCommand(command)
 	case "zypper":
 		return GetZypperPkgCommand(command)
+	case "void":
+		return GetVoidPkgCommand(command)
 	default:
 		return []string{"echo", pkgmanager + " is not implemented yet!"}
 	}
@@ -202,6 +206,34 @@ func GetZypperPkgCommand(command string) []string {
 	}
 }
 
+func GetVoidPkgCommand(command string) []string {
+
+	switch command {
+	case "autoremove":
+		return []string{"sudo", "xbps-remove", "-oO"}
+	case "clean":
+		return []string{"sudo", "xbps-remove", "-O"}
+	case "install":
+		return []string{"sudo", "xbps-install", "-S"}
+	case "list":
+		return []string{"sudo", "xbps-query", "-l"}
+	case "purge":
+		return []string{"sudo", "xbps-remove", "-R"}
+	case "remove":
+		return []string{"sudo", "xbps-remove"}
+	case "search":
+		return []string{"sudo", "xbps-query", "-Rs"}
+	case "show":
+		return []string{"sudo", "xbps-query", "-RS"}
+	case "update":
+		return []string{"sudo", "xbps-install", "-Su"}
+	case "upgrade":
+		return []string{"sudo", "xbps-install", "-Su"}
+	default:
+		return nil
+	}
+}
+
 func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 	var query_cmd string
 	switch c.containerType {
@@ -215,6 +247,8 @@ func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 		query_cmd = "apk -e info"
 	case ZYPPER:
 		query_cmd = "rpm -q"
+	case VOID:
+		query_cmd = "xbps-query"
 	default:
 		return false, errors.New("Cannot query package from unknown container")
 	}

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -24,6 +24,8 @@ func (c *Container) GetPkgCommand(command string) []string {
 		return GetDnfPkgCommand(command)
 	case APK:
 		return GetApkPkgCommand(command)
+	case ZYPPER:
+		return GetZypperPkgCommand(command)
 	default:
 		return nil
 	}
@@ -41,6 +43,8 @@ func GetDefaultPkgCommand(command string) []string {
 		return GetDnfPkgCommand(command)
 	case "apk":
 		return GetApkPkgCommand(command)
+	case "zypper":
+		return GetZypperPkgCommand(command)
 	default:
 		return []string{"echo", pkgmanager + " is not implemented yet!"}
 	}
@@ -169,6 +173,35 @@ func GetApkPkgCommand(command string) []string {
 	}
 }
 
+func GetZypperPkgCommand(command string) []string {
+	bin := "zypper"
+
+	switch command {
+	case "autoremove":
+		return []string{"sudo", bin, "rm -u"}
+	case "clean":
+		return []string{"sudo", bin, "clean"}
+	case "install":
+		return []string{"sudo", bin, "install"}
+	case "list":
+		return []string{"sudo", "rpm -qa"}
+	case "purge":
+		return []string{"sudo", bin, "remove"}
+	case "remove":
+		return []string{"sudo", bin, "remove"}
+	case "search":
+		return []string{"sudo", bin, "search"}
+	case "show":
+		return []string{"sudo", bin, "info"}
+	case "update":
+		return []string{"sudo", bin, "update"}
+	case "upgrade":
+		return []string{"sudo", bin, "update"}
+	default:
+		return nil
+	}
+}
+
 func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 	var query_cmd string
 	switch c.containerType {
@@ -180,6 +213,8 @@ func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 		query_cmd = "rpm -q"
 	case APK:
 		query_cmd = "apk -e info"
+	case ZYPPER:
+		query_cmd = "rpm -q"
 	default:
 		return false, errors.New("Cannot query package from unknown container")
 	}

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -26,8 +26,8 @@ func (c *Container) GetPkgCommand(command string) []string {
 		return GetApkPkgCommand(command)
 	case ZYPPER:
 		return GetZypperPkgCommand(command)
-	case VOID:
-		return GetVoidPkgCommand(command)
+	case XBPS:
+		return GetXbpsPkgCommand(command)
 	default:
 		return nil
 	}
@@ -47,8 +47,8 @@ func GetDefaultPkgCommand(command string) []string {
 		return GetApkPkgCommand(command)
 	case "zypper":
 		return GetZypperPkgCommand(command)
-	case "void":
-		return GetVoidPkgCommand(command)
+	case "xbps":
+		return GetXbpsPkgCommand(command)
 	default:
 		return []string{"echo", pkgmanager + " is not implemented yet!"}
 	}
@@ -206,7 +206,7 @@ func GetZypperPkgCommand(command string) []string {
 	}
 }
 
-func GetVoidPkgCommand(command string) []string {
+func GetXbpsPkgCommand(command string) []string {
 
 	switch command {
 	case "autoremove":
@@ -247,7 +247,7 @@ func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 		query_cmd = "apk -e info"
 	case ZYPPER:
 		query_cmd = "rpm -q"
-	case VOID:
+	case XBPS:
 		query_cmd = "xbps-query"
 	default:
 		return false, errors.New("Cannot query package from unknown container")

--- a/lang/en/cmd_help
+++ b/lang/en/cmd_help
@@ -28,7 +28,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the openSUSE repository.
-      --void          Install packages from the Void (Linux) repository.
+      --xbps          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/lang/en/cmd_help
+++ b/lang/en/cmd_help
@@ -28,6 +28,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the openSUSE repository.
+      --void          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/lang/en/cmd_help
+++ b/lang/en/cmd_help
@@ -1,26 +1,35 @@
-Usage: apx [options] [command] [arguments]
+Apx is a package manager with support for multiple sources allowing you to install packages in a managed container.
 
-Options:
-  -h, --help    Show this help message and exit
-  -v, --version Show version and exit
-  --aur         Install packages from the AUR repository
-  --dnf         Install packages from the Fedora repository
+Usage:
+  apx [command]
 
-Commands:
-    autoremove  Remove all unused packages
-    clean       Clean the apx package manager cache
-    enter       Enter the container's shell
-    export      Export/Recreate a program's desktop entry from a managed container
-    help        Show this help message and exit
-    init        Initialize a managed container
-    install     Install packages inside the container
-    list        List installed packages
-    log         Show logs (This command is yet to be implemented)
-    purge       Purge packages from the container
-    run         Run a command inside the container
-    remove      Remove packages from the container
-    search      Search for packages
-    show        Show details about a package
-    unexport    Unexport/Remove a program's desktop entry
-    update      Update the list of available packages
-    upgrade     Upgrade the system by installing/upgrading available packages
+Available Commands:
+  autoremove  Remove all unused packages automatically
+  clean       Clean the apx package manager cache
+  completion  Generate the autocompletion script for the specified shell
+  enter       Enter in the container shell
+  export      Export/Recreate a program's desktop entry from a managed container
+  help        Help about any command
+  init        Initialize the managed container
+  install     Install packages inside a managed container
+  list        List installed packages.
+  purge       Purge packages inside a managed container
+  remove      Remove packages inside a managed container.
+  run         Run a program inside a managed container.
+  search      Search for packages in a managed container.
+  show        Show details about a package
+  unexport    Unexport/Remove a program's desktop entry from a managed container
+  update      Update the list of available packages
+  upgrade     Upgrade the system by installing/upgrading available packages.
+
+Global Flags:
+      --apk           Install packages from the Alpine repository.
+      --apt           Install packages from the Ubuntu repository.
+      --aur           Install packages from the AUR (Arch User Repository).
+      --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
+      --zypper        Install packages from the OpenSUSE's Zypper repository.
+  -h, --help          help for apx
+  -n, --name string   Create or use custom container with this name.
+  -v, --version       version for apx
+
+Use "apx [command] --help" for more information about a command.

--- a/lang/en/cmd_help
+++ b/lang/en/cmd_help
@@ -27,7 +27,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the openSUSE's Zypper repository.
+      --zypper        Install packages from the openSUSE repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/lang/en/cmd_help
+++ b/lang/en/cmd_help
@@ -27,7 +27,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the OpenSUSE's Zypper repository.
+      --zypper        Install packages from the openSUSE's Zypper repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the OpenSUSE's Zypper repository.
+      --zypper        Install packages from the openSUSE's Zypper repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
-      --zypper        Install packages from the openSUSE's Zypper repository.
+      --zypper        Install packages from the openSUSE repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
+      --zypper        Install packages from the OpenSUSE's Zypper repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the openSUSE repository.
+      --void          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the openSUSE repository.
-      --void          Install packages from the Void (Linux) repository.
+      --xbps          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/man/apx.1
+++ b/man/apx.1
@@ -50,7 +50,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the OpenSUSE repository.
-      --void          Install packages from the Void (Linux) repository.
+      --xbps          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/man/apx.1
+++ b/man/apx.1
@@ -50,6 +50,7 @@ Global Flags:
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
       --zypper        Install packages from the OpenSUSE repository.
+      --void          Install packages from the Void (Linux) repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/man/apx.1
+++ b/man/apx.1
@@ -49,6 +49,7 @@ Global Flags:
       --apt           Install packages from the Ubuntu repository.
       --aur           Install packages from the AUR (Arch User Repository).
       --dnf           Install packages from the Fedora's DNF (Dandified YUM) repository.
+      --zypper        Install packages from the OpenSUSE repository.
   -h, --help          help for apx
   -n, --name string   Create or use custom container with this name.
   -v, --version       version for apx

--- a/settings/config.go
+++ b/settings/config.go
@@ -97,6 +97,8 @@ func GetHostInfo() (img string, pkgmanager string, err error) {
 		return "docker.io/library/fedora:" + distro_version, "dnf", nil
 	case "alpine":
 		return "docker.io/library/alpine:" + distro_version, "apk", nil
+	case "zypper":
+		return "registry.opensuse.org/opensuse/tumbleweed:latest" + distro_version, "zypper", nil
 	default:
 		return "", "", fmt.Errorf("Unsupported distro detected")
 	}

--- a/settings/config.go
+++ b/settings/config.go
@@ -99,8 +99,8 @@ func GetHostInfo() (img string, pkgmanager string, err error) {
 		return "docker.io/library/alpine:" + distro_version, "apk", nil
 	case "zypper":
 		return "registry.opensuse.org/opensuse/tumbleweed:latest" + distro_version, "zypper", nil
-	case "void":
-		return "ghcr.io/void-linux/void-linux:latest-full-x86_64" + distro_version, "void", nil
+	case "xbps":
+		return "ghcr.io/void-linux/void-linux:latest-full-x86_64" + distro_version, "xbps", nil
 	default:
 		return "", "", fmt.Errorf("Unsupported distro detected")
 	}

--- a/settings/config.go
+++ b/settings/config.go
@@ -99,6 +99,8 @@ func GetHostInfo() (img string, pkgmanager string, err error) {
 		return "docker.io/library/alpine:" + distro_version, "apk", nil
 	case "zypper":
 		return "registry.opensuse.org/opensuse/tumbleweed:latest" + distro_version, "zypper", nil
+	case "void":
+		return "ghcr.io/void-linux/void-linux:latest-full-x86_64" + distro_version, "void", nil
 	default:
 		return "", "", fmt.Errorf("Unsupported distro detected")
 	}


### PR DESCRIPTION
## Changes

- Added **openSUSE** (`zypper`) flag to apx.
- Added **Void** (Linux) [`xbps`] flag to apx.
- Fixed `export --bin`.

## Issues

- ~~`apx export --bin` doesn't work with Void. [But all other commands work as expected]~~, Fixed by @matbme.
- `autoremove` subcommand isn't present in `zypper`. [So it is marked as not implemented]

## Related PRs

https://github.com/Vanilla-OS/vanilla-control-center/pull/96

## Related Images

![neofetch in void container](https://media.discordapp.net/attachments/1031183436980961370/1066707056859549706/image.png?width=949&height=475)

Fig. Neofetch in Void (Linux) container [Renamed to `xbps`]

![neofetch in openSUSE container](https://media.discordapp.net/attachments/1031183436980961370/1066677941410484284/image.png?width=890&height=475)

Fig. Neofetch in openSUSE container

## Tests run

- All commands has been tested (by running `go build` and executing the binary) and works as expected and issues encountered are listed above.