### PR TITLE
Accurately check package is installed

### DIFF
--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -173,7 +173,7 @@ func (c *Container) IsPackageInstalled(pkgname string) (bool, error) {
 	var query_cmd string
 	switch c.containerType {
 	case APT:
-		query_cmd = "dpkg -l"
+		query_cmd = "dpkg -s"
 	case AUR:
 		query_cmd = "yay -Qi"
 	case DNF:


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/bitrise-io/bitrise/issues/433#issuecomment-256116057), using `dpkg -l`'s exit code for ensuring a package is installed is unreliable. Instead, we should be using `dpkg -s`.