### PR TITLE
fix(run): set interspersed flags to false for run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,6 +19,7 @@ func NewRunCommand() *cobra.Command {
 		Short:   "Run a program inside a managed container.",
 		RunE:    run,
 	}
+	cmd.Flags().SetInterspersed(false)
 	return cmd
 }
 


### PR DESCRIPTION
If applied this patch sets the "interspersed" property of flags to false, effectively treating all text after the `run` command as arguments to the `run` command and not flags to the `apx` command.

fixes #88 