### PR TITLE
init: Remove previous versions of yay

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -262,6 +262,16 @@ func (c *Container) Create() error {
 	spinner.Stop()
 
 	if c.containerType == AUR {
+		// Try to remove any older version downloaded by a previous Arch container
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatalf("error detecting user home directory: %v", err)
+		}
+		yay_dir := fmt.Sprintf("%v/.local/src/yay", home)
+		if err := os.RemoveAll(yay_dir); err != nil {
+			log.Fatalf("error removing older yay version: %v", err)
+		}
+
 		DownloadYay()
 		c.Run(GetAurPkgCommand("install-yay")...)
 	}

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -112,7 +112,7 @@ func GetAurPkgCommand(command string) []string {
 	// specials
 	case "install-yay":
 		return []string{
-			"bash", "-c", "cd ~/.local/src/yay  && tar -xvf yay.tar.gz && cd yay_*_x86_64* && sudo cp yay /usr/bin",
+			"bash", "-c", "cd ~/.local/src/yay  && tar -xf yay.tar.gz && cd yay_*_x86_64* && sudo cp yay /usr/bin",
 		}
 	default:
 		return nil


### PR DESCRIPTION
When running `apx --aur init` when another Arch container had already been created in the past, the initialization script would download a newer version of `yay` and break installation, since there would be two directories in `~/.local/src/yay` matching the wildcard. 

This PR removes any existing versions of Yay from that directory before downloading it.

As a bonus, I also removed the `-v` flag from `tar` so it doesn't output random file names during initialization.