### PR TITLE
`--all` for certain actions

### DIFF
--- a/cmd/autoremove.go
+++ b/cmd/autoremove.go
@@ -10,6 +10,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vanilla-os/apx/core"
 )
 
 func NewAutoRemoveCommand() *cobra.Command {
@@ -19,10 +20,19 @@ func NewAutoRemoveCommand() *cobra.Command {
 		Short:   "Remove all unused packages automatically",
 		RunE:    autoRemove,
 	}
+
+	cmd.Flags().BoolP("all", "a", false, "Apply for all containers.")
 	return cmd
 }
 
 func autoRemove(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("all").Changed {
+		if err := core.ApplyForAll("autoremove", []string{}); err != nil {
+			return err
+		}
+
+		return nil
+	}
 
 	command := append([]string{}, container.GetPkgCommand("autoremove")...)
 	command = append(command, args...)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -10,6 +10,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vanilla-os/apx/core"
 )
 
 func NewCleanCommand() *cobra.Command {
@@ -19,10 +20,18 @@ func NewCleanCommand() *cobra.Command {
 		Short:   "Clean the apx package manager cache",
 		RunE:    clean,
 	}
+	cmd.Flags().BoolP("all", "a", false, "Apply for all containers.")
 	return cmd
 }
 
 func clean(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("all").Changed {
+		if err := core.ApplyForAll("clean", []string{}); err != nil {
+			return err
+		}
+
+		return nil
+	}
 
 	command := append([]string{}, container.GetPkgCommand("clean")...)
 	command = append(command, args...)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -10,6 +10,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vanilla-os/apx/core"
 )
 
 func NewUpdateCommand() *cobra.Command {
@@ -19,11 +20,24 @@ func NewUpdateCommand() *cobra.Command {
 		Short:   "Update the list of available packages",
 		RunE:    update,
 	}
+	cmd.Flags().BoolP("all", "a", false, "Apply for all containers.")
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	return cmd
 }
 
 func update(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("all").Changed {
+        var flags []string
+        if cmd.Flag("assume-yes").Value.String() == "true" {
+            flags = append(flags, "-y")
+        }
+
+		if err := core.ApplyForAll("update", flags); err != nil {
+			return err
+		}
+
+		return nil
+	}
 
 	command := append([]string{}, container.GetPkgCommand("update")...)
 	command = append(command, args...)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -10,6 +10,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vanilla-os/apx/core"
 )
 
 func NewUpgradeCommand() *cobra.Command {
@@ -19,11 +20,24 @@ func NewUpgradeCommand() *cobra.Command {
 		Short:   "Upgrade the system by installing/upgrading available packages.",
 		RunE:    upgrade,
 	}
+	cmd.Flags().BoolP("all", "a", false, "Apply for all containers.")
 	cmd.Flags().BoolP("assume-yes", "y", false, "Proceed without manual confirmation.")
 	return cmd
 }
 
 func upgrade(cmd *cobra.Command, args []string) error {
+	if cmd.Flag("all").Changed {
+        var flags []string
+        if cmd.Flag("assume-yes").Value.String() == "true" {
+            flags = append(flags, "-y")
+        }
+
+		if err := core.ApplyForAll("upgrade", flags); err != nil {
+			return err
+		}
+
+		return nil
+	}
 
 	command := append([]string{}, container.GetPkgCommand("upgrade")...)
 	command = append(command, args...)

--- a/core/container.go
+++ b/core/container.go
@@ -35,6 +35,10 @@ const (
 	XBPS   ContainerType = iota // 5
 )
 
+// How many container types we offer. Must be always the same
+// as the number of options above!
+const CONTAINER_TYPES = 6
+
 type Container struct {
 	containerType ContainerType
 	customName    string
@@ -558,4 +562,24 @@ func (c *Container) Exists() bool {
 	// fmt.Println("output: ", string(output))
 
 	return len(output) > 0
+}
+
+func ApplyForAll(command string, flags []string) error {
+	for i := 0; i < CONTAINER_TYPES; i++ {
+		container := NewContainer(ContainerType(i))
+		name := container.GetContainerName()
+
+		log.Default().Println(fmt.Sprintf("Running %s in %s...", command, name))
+
+		command := append([]string{}, container.GetPkgCommand(command)...)
+		for _, flag := range flags {
+			command = append(command, flag)
+		}
+
+		if err := container.Run(command...); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/core/container.go
+++ b/core/container.go
@@ -573,6 +573,7 @@ func ApplyForAll(command string, flags []string) error {
 
 		name := container.GetContainerName()
 
+        fmt.Println()
 		log.Default().Println(fmt.Sprintf("Running %s in %s...", command, name))
 
 		command := append([]string{}, container.GetPkgCommand(command)...)

--- a/core/container.go
+++ b/core/container.go
@@ -567,6 +567,10 @@ func (c *Container) Exists() bool {
 func ApplyForAll(command string, flags []string) error {
 	for i := 0; i < CONTAINER_TYPES; i++ {
 		container := NewContainer(ContainerType(i))
+		if !container.Exists() {
+			continue
+		}
+
 		name := container.GetContainerName()
 
 		log.Default().Println(fmt.Sprintf("Running %s in %s...", command, name))


### PR DESCRIPTION
Adds the new flag `--all` for `autoremove`, `clean`, `update`, and `upgrade`, which will repeat the action for all existing containers.

Fixes #60 (and maybe #85)