### PR TITLE
Read config from /usr/share/apx as well

### DIFF
--- a/settings/config.go
+++ b/settings/config.go
@@ -30,6 +30,7 @@ var Cnf *Config
 
 func init() {
 	viper.AddConfigPath("/etc/apx/")
+	viper.AddConfigPath("/usr/share/apx/")
 	viper.AddConfigPath("config/")
 	viper.SetConfigName("config")
 	viper.SetConfigType("json")


### PR DESCRIPTION
Application/distro default configuration is normally put in /usr/share and the user can copy the config file to /etc to override it. This way the distro can make sure to always provide a correct default configuration without having to deal with not overwriting the user's changes.