### PR TITLE
Add allow-unfree flag back to apx --nix

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -50,6 +50,13 @@ func NewInstallCommand() *cmdr.Command {
 			apx.Trans("install.sideload"),
 			false,
 		),
+	).WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"allow-unfree",
+			"",
+			apx.Trans("nixinstall.allowUnfree"),
+			false,
+		),
 	)
 	/*
 				Example: `apx install htop git


### PR DESCRIPTION
This change adds back the --allow-unfree flag to the `apx install` command when the `nix` package manager is used.