### PR TITLE
fix: require package name for nix upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -9,6 +9,8 @@ package cmd
 */
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/apx/core"
 	"github.com/vanilla-os/orchid/cmdr"
@@ -68,7 +70,9 @@ func upgrade(cmd *cobra.Command, args []string) error {
 }
 
 func upgradePackage(cmd *cobra.Command, args []string) error {
-
+	if len(args) < 1 {
+		return errors.New(apx.Trans("nixupgrade.atleastone"))
+	}
 	err := core.NixUpgradePackage(args[0])
 	if err != nil {
 		return err

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -83,6 +83,7 @@ nixinstall:
   success: "Successfully installed package."
 nixupgrade:
   success: "Successfully upgraded package."
+  atleastone: "At least one package name required."
 purge:
   use: "purge <packages>"
   long: "Purge packages inside a managed container"


### PR DESCRIPTION
If approved, this PR will fix a bad index error when running `apx --nix upgrade` with no arguments.