### PR TITLE
Use binary name to (un)export desktop app

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -139,9 +139,9 @@ func install(cmd *cobra.Command, args []string) error {
 						return err
 					}
 				}
-			}
 
-			container.ExportDesktopEntry(pkg)
+                container.ExportDesktopEntry(binary)
+			}
 		}
 	}
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -44,14 +44,14 @@ func remove(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, pkg := range args {
-		container.RemoveDesktopEntry(pkg)
-
         binaries, err := container.BinariesProvidedByPackage(pkg)
         if err != nil {
             return err
         }
 
         for _, binary := range binaries {
+            container.RemoveDesktopEntry(binary)
+
             err := container.RemoveBinary(binary, false)
             if err != nil {
                 cmdr.Error.Printf("Error unexporting binary: %s\n", err)


### PR DESCRIPTION
Export/unexport desktop application with binary name, which solves the issue where some .desktop files weren't removed when uninstalling a package.

Closes #32.