### PR TITLE
sideload: Copy deb instead of moving

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -101,7 +101,7 @@ func install(cmd *cobra.Command, args []string) error {
 
 			return fmt.Errorf(apx.Trans("install.sideArgs"))
 		}
-		path, err := core.MoveToUserTemp(args[0])
+		path, err := core.CopyToUserTemp(args[0])
 		if err != nil {
 			return fmt.Errorf(apx.Trans("install.sideUserTemp", err))
 		}

--- a/core/utils.go
+++ b/core/utils.go
@@ -37,7 +37,7 @@ func AskConfirmation(s string) bool {
 	return false
 }
 
-func MoveToUserTemp(path string) (string, error) {
+func CopyToUserTemp(path string) (string, error) {
 	user, err := user.Current()
 	if err != nil {
 		return "", err
@@ -52,7 +52,21 @@ func MoveToUserTemp(path string) (string, error) {
 
 	fileName := filepath.Base(path)
 	newPath := filepath.Join(cacheDir, fileName)
-	if err := os.Rename(path, newPath); err != nil {
+
+	pathContents, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer pathContents.Close()
+
+	newPathContents, err := os.Create(newPath)
+	if err != nil {
+		return "", err
+	}
+	defer newPathContents.Close()
+
+	_, err = newPathContents.ReadFrom(pathContents)
+	if err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Automatically moving the deb file without user consent is bad. We should copy it to a usertemp instead.

Closes #91.