### PR TITLE
add allow-insecure flag to install

### DIFF
--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -69,11 +69,14 @@ func initNix(cmd *cobra.Command, args []string) error {
 	}
 
 	unfree, err := cmdr.Confirm.Show(apx.Trans("nixinit.unfree"))
-
 	if err != nil {
 		return err
 	}
-	err = core.NixInit(unfree)
+	insecure, err := cmdr.Confirm.Show(apx.Trans("nixinit.insecure"))
+	if err != nil {
+		return err
+	}
+	err = core.NixInit(unfree, insecure)
 	if err != nil {
 		return err
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -57,6 +57,13 @@ func NewInstallCommand() *cmdr.Command {
 			apx.Trans("nixinstall.allowUnfree"),
 			false,
 		),
+	).WithBoolFlag(
+		cmdr.NewBoolFlag(
+			"allow-insecure",
+			"",
+			apx.Trans("nixinstall.allowInsecure"),
+			false,
+		),
 	)
 	/*
 				Example: `apx install htop git
@@ -153,8 +160,12 @@ func installPackage(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("allow-unfree") {
 		allowUnfree = true
 	}
+	allowInsecure := false
+	if cmd.Flags().Changed("allow-insecure") {
+		allowInsecure = true
+	}
 
-	err := core.NixInstallPackage(args, allowUnfree)
+	err := core.NixInstallPackage(args, allowUnfree, allowInsecure)
 	if err != nil {
 		return err
 	}

--- a/core/nix.go
+++ b/core/nix.go
@@ -398,5 +398,5 @@ var singleUserCommand = "sh <(curl -L https://nixos.org/nix/install) --no-daemon
 
 var nixConf = "experimental-features = nix-command flakes"
 var unfreeConf = "NIXPKGS_ALLOW_UNFREE=1"
-var insecureConf = "NIXPKGS_ALLOW_UNFREE=1"
+var insecureConf = "NIXPKGS_ALLOW_INSECURE=1"
 var xdgConfig = "export XDG_DATA_DIRS=$HOME/.nix-profile/share:$XDG_DATA_DIRS"

--- a/core/nix.go
+++ b/core/nix.go
@@ -165,7 +165,7 @@ func NixRemovePackage(pkgs []string) error {
 
 }
 
-func NixInit(allowUnfree bool) error {
+func NixInit(allowUnfree, allowInsecure bool) error {
 	// get user name for the systemd units
 	user := os.Getenv("USER")
 	if user == "" {
@@ -309,6 +309,24 @@ func NixInit(allowUnfree bool) error {
 			return err
 		}
 	}
+	if allowInsecure {
+		systemEnvDir := path.Join(homedir, ".config", "environment.d")
+
+		err = os.MkdirAll(systemEnvDir, 0755)
+		if err != nil {
+			log.Default().Printf("error creating user environment configuration directory")
+			return err
+		}
+		nixInsecureFile := path.Join(systemEnvDir, "01-nixinsecure.conf")
+		insecureEnv, err := os.Create(nixInsecureFile)
+		if err != nil {
+			return err
+		}
+		_, err = insecureEnv.Write([]byte(insecureConf))
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 
 }
@@ -380,4 +398,5 @@ var singleUserCommand = "sh <(curl -L https://nixos.org/nix/install) --no-daemon
 
 var nixConf = "experimental-features = nix-command flakes"
 var unfreeConf = "NIXPKGS_ALLOW_UNFREE=1"
+var insecureConf = "NIXPKGS_ALLOW_UNFREE=1"
 var xdgConfig = "export XDG_DATA_DIRS=$HOME/.nix-profile/share:$XDG_DATA_DIRS"

--- a/core/nix.go
+++ b/core/nix.go
@@ -18,7 +18,7 @@ type UnitData struct {
 	User string
 }
 
-func NixInstallPackage(pkgs []string, unfree bool) error {
+func NixInstallPackage(pkgs []string, unfree, insecure bool) error {
 	spinner, err := cmdr.Spinner.Start(fmt.Sprintf("Installing %v...", pkgs))
 	if err != nil {
 		return err
@@ -43,7 +43,12 @@ func NixInstallPackage(pkgs []string, unfree bool) error {
 	}
 
 	install := exec.Command(cmd[0], cmd[1:]...)
-	install.Env = append(install.Env, "NIXPKGS_ALLOW_UNFREE=1")
+	if insecure {
+		install.Env = append(install.Env, "NIXPKGS_ALLOW_INSECURE=1")
+	}
+	if unfree {
+		install.Env = append(install.Env, "NIXPKGS_ALLOW_UNFREE=1")
+	}
 
 	var errOut bytes.Buffer
 	install.Stderr = &errOut

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -81,6 +81,7 @@ nixinstall:
   long: "Install a package from the `nixpkgs` repository as a flake in the default nix profile."
   short: "Install nix package"
   allowUnfree: "Allow packages with unfree licenses"
+  allowInsecure: "Allow packages with known vulnerabilities."
   error: "error installing packages"
   runInit: "Have you run the `init` command yet?"
   success: "Successfully installed package."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -68,7 +68,7 @@ nixinit:
   long: "Initializes a custom installation of nix by creating $HOME/.nix and setting up some SystemD units to mount it as /nix."
   short: "Initialize nix repository"
   confirm: "This will create a '.nix' folder in your home directory and set up some SystemD units to mount that folder at /nix before running the installation. Confirm 'y' to continue."
-  unfree: "Would you like to allow 'unfree' packages without Open Source licenses (Visual Studio Code, Spotify, etc)."
+  unfree: "Would you like to allow 'unfree' packages without Open Source licenses (Visual Studio Code, Spotify, etc)?"
   insecure: "Would you like to allow 'insecure' packages (software with known vulnerabilities)?"
   swcenter: "Would you like to install the Nix Software Center - a graphical software manager for Nix?"
   success: "Installation complete. Reboot to start using nix."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -70,7 +70,6 @@ nixinit:
   confirm: "This will create a '.nix' folder in your home directory and set up some SystemD units to mount that folder at /nix before running the installation. Confirm 'y' to continue."
   unfree: "Would you like to allow 'unfree' packages without Open Source licenses (Visual Studio Code, Spotify, etc)."
   insecure: "Would you like to allow 'insecure' packages (software with known vulnerabilities)."
-
   swcenter: "Would you like to install the Nix Software Center - a graphical software manager for Nix?"
   success: "Installation complete. Reboot to start using nix."
 nixremove:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -69,7 +69,7 @@ nixinit:
   short: "Initialize nix repository"
   confirm: "This will create a '.nix' folder in your home directory and set up some SystemD units to mount that folder at /nix before running the installation. Confirm 'y' to continue."
   unfree: "Would you like to allow 'unfree' packages without Open Source licenses (Visual Studio Code, Spotify, etc)."
-  insecure: "Would you like to allow 'insecure' packages (software with known vulnerabilities)."
+  insecure: "Would you like to allow 'insecure' packages (software with known vulnerabilities)?"
   swcenter: "Would you like to install the Nix Software Center - a graphical software manager for Nix?"
   success: "Installation complete. Reboot to start using nix."
 nixremove:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -69,6 +69,8 @@ nixinit:
   short: "Initialize nix repository"
   confirm: "This will create a '.nix' folder in your home directory and set up some SystemD units to mount that folder at /nix before running the installation. Confirm 'y' to continue."
   unfree: "Would you like to allow 'unfree' packages without Open Source licenses (Visual Studio Code, Spotify, etc)."
+  insecure: "Would you like to allow 'insecure' packages (software with known vulnerabilities)."
+
   swcenter: "Would you like to install the Nix Software Center - a graphical software manager for Nix?"
   success: "Installation complete. Reboot to start using nix."
 nixremove:


### PR DESCRIPTION
If merged, this change will add a flag to `apx install` to be used with the nix package manager to allow insecure packages to be installed.  Insecure in this case means packages with known vulnerabilities - davinci-resolve is the test case.

This also modifies the `--nix init` command to add a prompt asking if the user wants to allow insecure packages.

fixes #151 
