### PR TITLE
Add makefile and distrobox as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "distrobox"]
+	path = distrobox
+	url = https://github.com/89luca89/distrobox

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+PREFIX=/usr/
+DESTDIR=/
+BINARY_NAME=apx
+
+all: build
+
+build:
+	go build -o ${BINARY_NAME}
+
+install:
+	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}
+	mkdir -p ${DESTDIR}/etc/apx
+	sed -i 's|/usr/share/apx/distrobox|${DESTDIR}${PREFIX}/share/apx/distrobox|g' config/config.json
+	install -Dm644 config/config.json ${DESTDIR}/etc/apx/config.json
+	mkdir -p ${DESTDIR}${PREFIX}/share/apx
+	sh distrobox/install --prefix ${DESTDIR}${PREFIX}/share/apx
+	mv ${DESTDIR}${PREFIX}/share/apx/bin/distrobox* ${DESTDIR}${PREFIX}/share/apx/.
+
+clean:
+	rm -f ${BINARY_NAME}
+	go clean

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINARY_NAME=apx
 all: build
 
 build:
-	go build -o ${BINARY_NAME}
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o ${BINARY_NAME}
 
 install:
 	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 install:
 	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}
 	mkdir -p ${DESTDIR}/etc/apx
-	sed -i 's|/usr/share/apx/distrobox|${DESTDIR}${PREFIX}/share/apx/distrobox|g' config/config.json
+	sed -i 's|/usr/share/apx/distrobox|${PREFIX}/share/apx/distrobox|g' config/config.json
 	install -Dm644 config/config.json ${DESTDIR}/etc/apx/config.json
 	mkdir -p ${DESTDIR}${PREFIX}/share/apx
 	sh distrobox/install --prefix ${DESTDIR}${PREFIX}/share/apx

--- a/README.md
+++ b/README.md
@@ -71,44 +71,37 @@ Apx has been designed in a distro-agnostic manner, allowing it to work with any 
 - You must have `git` installed to clone the repository.
 - You must have `curl` installed for the Distrobox script.
 - You must have either `podman` or `docker` installed.
+- You must have `make` installed for the installation
 
 ### Procedure
 
-- Navigate to the directory you want to clone the repository in using `cd`.
-- Clone apx's repository using `git`:-
+- Clone apx's repository using `git` and enter it using `cd`:-
 
-```bash
-git clone https://github.com/Vanilla-OS/apx.git
-```
-
-- You will have to enter the cloned repository and compile Apx with `go`:-
-
-```bash
+``` bash
+git clone --recursive https://github.com/Vanilla-OS/apx.git
 cd apx
-go build
 ```
 
-- For the Apx binary to work in the terminal, you need to add the binary to your PATH using the following command:-
+- Use `make build` to build apx:-
 
-```bash
-sudo cp apx /usr/bin
+``` bash
+make build
 ```
 
-> In the above command, you can replace the path with: `/usr/local/bin/` or `~/.local/bin` if preferred.
+- Install apx using `make install`:-
 
-- Create a directory to store Distrobox and configure Apx using the following steps:-
-
-```bash
-sudo mkdir /etc/apx
-sudo cp config/config.json /etc/apx/
-sudo mkdir /usr/lib/apx
+``` bash
+make install
 ```
+The prefix or installation destination can be changed using `PREFIX` and `DESTDIR` respectively:
 
-- Now, we need to install the Distrobox binary and move it using the following steps:-
-
-```bash
-curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local
-sudo mv ~/.local/share/distrobox* /usr/lib/apx
+To install apx into `~/.local` for example:
+``` bash
+make install PREFIX=$HOME/.local
+```
+or into a seperate root:
+``` bash
+make install DESTDIR=$HOME/altroot
 ```
 
 > Note:- Apx uses a fork of Distrobox called `micro-distrobox`, but it is currently unavailable for other distributions, affecting the export of desktop entries.

--- a/config/config.json
+++ b/config/config.json
@@ -2,5 +2,5 @@
     "containername": "apx_managed",
     "image": "docker.io/library/ubuntu",
     "pkgmanager": "apt",
-    "distroboxpath": "/usr/lib/apx/distrobox"
+    "distroboxpath": "/home/axtlos/Projects/apx/installdir/usr//share/apx/distrobox"
 }

--- a/config/config.json
+++ b/config/config.json
@@ -2,5 +2,5 @@
     "containername": "apx_managed",
     "image": "docker.io/library/ubuntu",
     "pkgmanager": "apt",
-    "distroboxpath": "/home/axtlos/Projects/apx/installdir/usr//share/apx/distrobox"
+    "distroboxpath": "/usr/share/apx/distrobox"
 }


### PR DESCRIPTION
This adds `distrobox` as a submodule in this repo and creates a Makefile to make installing and building apx easier.