### PR TITLE
Fix permission error when running make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 
 install:
 	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}
-	mkdir -p ${DESTDIR}/etc/apx
+	sudo mkdir -p ${DESTDIR}/etc/apx
 	sed -i 's|/usr/share/apx/distrobox|${PREFIX}/share/apx/distrobox|g' config/config.json
 	sudo install -Dm644 config/config.json ${DESTDIR}/etc/apx/config.json
 	mkdir -p ${DESTDIR}${PREFIX}/share/apx


### PR DESCRIPTION
Runs `mkdir` as root when trying to create `/etc/apx`, fixes #166 