### PR TITLE
Tweaks to command behaviour for the AUR container

### DIFF
--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -106,7 +106,7 @@ func GetAurPkgCommand(command string) []string {
 	case "show":
 		return []string{bin, "-Si"}
 	case "update":
-		return []string{bin, "-Syu"}
+		return []string{bin, "-Sy"}
 	case "upgrade":
 		return []string{bin, "-Su"}
 

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -96,7 +96,7 @@ func GetAurPkgCommand(command string) []string {
 	case "install":
 		return []string{bin, "-S"}
 	case "list":
-		return []string{bin, "-Qm"}
+		return []string{bin, "-Q"}
 	case "purge":
 		return []string{bin, "-Rn"}
 	case "remove":

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -92,7 +92,7 @@ func GetAurPkgCommand(command string) []string {
 	case "autoremove":
 		return []string{"echo", "Not implemented yet! "}
 	case "clean":
-		return []string{bin, "-Yc"}
+		return []string{bin, "-Sc"}
 	case "install":
 		return []string{bin, "-S"}
 	case "list":

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -98,9 +98,9 @@ func GetAurPkgCommand(command string) []string {
 	case "list":
 		return []string{bin, "-Qm"}
 	case "purge":
-		return []string{bin, "-R"}
+		return []string{bin, "-Rn"}
 	case "remove":
-		return []string{bin, "-Rs"}
+		return []string{bin, "-R"}
 	case "search":
 		return []string{bin, "-Ss"}
 	case "show":

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -90,7 +90,7 @@ func GetAurPkgCommand(command string) []string {
 	switch command {
 	// defaults
 	case "autoremove":
-		return []string{"echo", "Not implemented yet! "}
+		return []string{bin, "-Yc"}
 	case "clean":
 		return []string{bin, "-Sc"}
 	case "install":

--- a/core/pkgmanager.go
+++ b/core/pkgmanager.go
@@ -106,9 +106,9 @@ func GetAurPkgCommand(command string) []string {
 	case "show":
 		return []string{bin, "-Si"}
 	case "update":
-		return []string{bin, "-Sy"}
+		return []string{"echo", "Not implemented for AUR. Use upgrade instead!"}
 	case "upgrade":
-		return []string{bin, "-Su"}
+		return []string{bin, "-Syu"}
 
 	// specials
 	case "install-yay-deps":


### PR DESCRIPTION
- `update` command now only displays a message
  - This is due to installing upgraded packages through a command that usually only syncs package listings in other containers possibly causing unexpected behaviour for the user
  - `-Sy` was not used due to stability concerns, as updating package listings without installing the updated packages can cause AUR builds to fail
  - This is not an error message, and is instead a simple `echo`. This is to avoid interfering with the `--all` flag
- `upgrade` command now also syncs package repos (`-Syu`) due to `update` no longer being implemented
- `clean` command now mirrors the behaviour of `apt clean`, no longer behaving like `apt autoremove`
- `autoremove` command is now implemented
- `list` command now lists all packages, rather than only packages installed from the AUR. This mirrors `apt list` behaviour
- Corrected `remove` command acting as `apt autoremove`, now mirrors `apt remove` behaviour
- Corrected `purge` command acting as `apt remove`, now mirrors `apt purge` behaviour