### PR TITLE
Produced exit codes are now actually used as exit codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,9 @@ package main
 
 import (
 	"embed"
+	"strings"
+	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/apx/cmd"
@@ -144,9 +147,18 @@ func main() {
 	update.GroupID = containerGroup.ID
 	root.AddCommand(cmd.AddContainerFlags(update))
 	cmd.AddContainerFlags(root)
+
 	// run the app
 	err := apx.Run()
+
 	if err != nil {
 		cmdr.Error.Println(err)
+
+		if strings.Contains(err.Error(), "exit status ") {
+			errorcode, _ := strconv.Atoi(strings.Trim(err.Error(), "exit status "))
+			os.Exit(errorcode)
+		}
+		// No error code present, just use error code 1
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR:
![image](https://user-images.githubusercontent.com/48618519/234381688-53dc2229-9d62-4fdf-9377-67217f698a67.png)

Current:
![image](https://user-images.githubusercontent.com/48618519/234381851-b24ba6bc-f870-4f8f-8ccc-92da1e0ef620.png)

Additionally, if no error code is given but there was still an error, an exit code of 1 is now used