### PR TITLE
Fixed "not available core component" error

### DIFF
--- a/config/apx.json
+++ b/config/apx.json
@@ -1,5 +1,5 @@
 {
     "apxPath": "/usr/share/apx",
-    "distroboxpath": "/usr/lib/apx/distrobox",
+    "distroboxpath": "/usr/share/apx/distrobox",
     "storageDriver": "btrfs"
 }


### PR DESCRIPTION
After the building of the project, the `distrobox` binary is not anymore in `/usr/lib/apx/distrobox` but it is stored in `/usr/share/apx/distrobox`. This fix solves the following error when APX is created by building from source:
```
One or more core components are not available. 
Please refer to our documentation at https://documentation.vanillaos.org/
2023/06/25 22:32:04 distrobox is not installed
```