### PR TITLE
Fixed config file stale name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}
 	sudo mkdir -p ${DESTDIR}/etc/apx
 	sed -i 's|/usr/share/apx/distrobox|${PREFIX}/share/apx/distrobox|g' config/apx.json
-	sudo install -Dm644 config/apx.json ${DESTDIR}/etc/apx/config.json
+	sudo install -Dm644 config/apx.json ${DESTDIR}/etc/apx/apx.json
 	mkdir -p ${DESTDIR}${PREFIX}/share/apx
 	sh distrobox/install --prefix ${DESTDIR}${PREFIX}/share/apx
 	mv ${DESTDIR}${PREFIX}/share/apx/bin/distrobox* ${DESTDIR}${PREFIX}/share/apx/.


### PR DESCRIPTION
Changed `/etc/apx/config.json` to `/etc/apx/apx.json` name because `config.json` was the old name of the configuration file that currently is `apx.json`. This PR will fix the error generated by running `apx` binary generated by the building of `apx-git` package:
```
Unable to read config file: 
	Config File "apx" Not Found in "[/home/athena/athena-apx/config /home/athena/config /home/athena/.config/apx /etc/apx /usr/share/apx]"
```
Indeed, it cannot find `Config File "apx"` because it has still the old name `config.json`.