### PR TITLE
Deleted rows related to ${DESTDIR}${PREFIX}/share/man/*/man1/apx*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ install-manpages:
 	mkdir -p ${DESTDIR}${PREFIX}/share/man/man1
 	cp -r man/* ${DESTDIR}${PREFIX}/share/man/.
 	chmod 644 ${DESTDIR}${PREFIX}/share/man/man1/apx*
-	chmod 644 ${DESTDIR}${PREFIX}/share/man/*/man1/apx*
 
 uninstall:
 	sudo rm ${DESTDIR}${PREFIX}/bin/apx
@@ -29,7 +28,6 @@ uninstall:
 
 uninstall-manpages:
 	sudo rm -rf ${DESTDIR}${PREFIX}/share/man/man1/apx*
-	sudo rm -rf ${DESTDIR}${PREFIX}/share/man/*/man1/apx*
 
 clean:
 	rm -f ${BINARY_NAME}


### PR DESCRIPTION
`chmod 644 ${DESTDIR}${PREFIX}/share/man/*/man1/apx*` causes an error during the `sudo make install` because currently, a folder between `man` and `man1` does not exist, so the `chmod` in error and the building fails.

Since in the source files there is only `man/man1/apx.1`, it is suggested to delete the rows containing `${DESTDIR}${PREFIX}/share/man/*/man1/apx*`.