### PR TITLE
CI: Update workflows and set branch to v2

### DIFF
--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -1,0 +1,40 @@
+name: Go (PR)
+
+on:    
+  pull_request_target:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.vanillaos.org/vanillaos/pico:main
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.19
+
+    - name: Install build dependencies
+      run: |
+          apt-get update
+          apt-get install -y pkg-config build-essential
+    - name: Build
+      run: go build -o apx
+
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -2,7 +2,7 @@ name: Go (PR)
 
 on:    
   pull_request_target:
-    branches: [ "main" ]
+    branches: [ "v2" ]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "v2" ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19
 
@@ -30,11 +30,22 @@ jobs:
     - name: Compress
       run: tar -czvf apx.tar.gz apx
 
-    - uses: "marvinpinto/action-automatic-releases@latest"
+    - uses: softprops/action-gh-release@v1
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "continuous"
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "continuous"
         prerelease: true
-        title: "Continuous Build"
+        name: "Continuous Build"
         files: |
           apx.tar.gz
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,16 +9,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v4
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=Vanilla-OS_apx_AYiLLt9U9CPJrZw6oxBN
+sonar.projectName=apx
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go
+
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-


### PR DESCRIPTION
Updated version of https://github.com/Vanilla-OS/apx/pull/233 with default branch set to `v2`.