### PR TITLE
fix:[close #292] Change distrobox install path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ install:
 	sudo mkdir -p ${DESTDIR}/etc/apx
 	sed -i 's|/usr/share/apx/distrobox|${PREFIX}/share/apx/distrobox|g' config/apx.json
 	sudo install -Dm644 config/apx.json ${DESTDIR}/etc/apx/apx.json
-	mkdir -p ${DESTDIR}${PREFIX}/share/apx
-	sh distrobox/install --prefix ${DESTDIR}${PREFIX}/share/apx
-	mv ${DESTDIR}${PREFIX}/share/apx/bin/distrobox* ${DESTDIR}${PREFIX}/share/apx/.
+	mkdir -p ${DESTDIR}${PREFIX}/share/apx/distrobox
+	sh distrobox/install --prefix ${DESTDIR}${PREFIX}/share/apx/distrobox
+	mv ${DESTDIR}${PREFIX}/share/apx/distrobox/bin/distrobox* ${DESTDIR}${PREFIX}/share/apx/distrobox/.
 
 install-manpages:
 	mkdir -p ${DESTDIR}${PREFIX}/share/man/man1


### PR DESCRIPTION
Change the distrobox installation prefix to apx/distrobox so that apx finds distrobox in the expected location.