### PR TITLE
Feat: Display distrobox output in create command

### DIFF
--- a/core/dbox.go
+++ b/core/dbox.go
@@ -246,7 +246,7 @@ func (d *dbox) CreateContainer(name string, image string, additionalPackages []s
 	}
 	engineFlags = append(engineFlags, "--label=manager=apx")
 
-	_, err := d.RunCommand("create", args, engineFlags, false, true, true, rootFull)
+	_, err := d.RunCommand("create", args, engineFlags, false, false, false, rootFull)
 	// fmt.Println(string(out))
 	return err
 }


### PR DESCRIPTION
Displays the distrobox output when creating a new command, allowing the user to track the status of the command.