### PR TITLE
fix: typo in subsystems string

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -345,7 +345,7 @@ subsystems:
         description: "The stack to use."
       home:
         description: "The custom home directory of the subsystem."
-      info:
+      init:
         description: "Use systemd inside the subsystem."
   rm:
     description: "Remove the specified subsystem."


### PR DESCRIPTION
![image](https://github.com/Vanilla-OS/apx/assets/26346867/a974099b-34a1-41c1-b5b8-252e391176ff)
