### PR TITLE
Revert "fu/ci: update Sonar workflow to run on push to main"

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,8 +1,6 @@
 name: Sonar
 
 on:
-  push:
-    branches: [ 'main' ]
   pull_request_target:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Reverts Vanilla-OS/apx#349

The push parameter isn't required in the Sonar workflow as automated Sonar check already runs on the main branch and it provides a report on commit like this https://github.com/Vanilla-OS/apx/runs/24139228654. So having both is redundant, so this PR reverts the change.