### PR TITLE
fix: missing strings, refactor runtime commands

### DIFF
--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -339,12 +339,12 @@ func newStack(cmd *cobra.Command, args []string) error {
 		var pkgManagerIndex int
 		_, err := fmt.Scanln(&pkgManagerIndex)
 		if err != nil {
-			cmdr.Error.Println(apx.Trans("apx.error.invalidInput"))
+			cmdr.Error.Println(apx.Trans("apx.errors.invalidInput"))
 			return nil
 		}
 
 		if pkgManagerIndex < 1 || pkgManagerIndex > len(pkgManagers) {
-			cmdr.Error.Println(apx.Trans("apx.error.invalidInput"))
+			cmdr.Error.Println(apx.Trans("apx.errors.invalidInput"))
 			return nil
 		}
 

--- a/cmd/subsyStems.go
+++ b/cmd/subsyStems.go
@@ -204,13 +204,13 @@ func newSubSystem(cmd *cobra.Command, args []string) error {
 		cmdr.Info.Println(apx.Trans("subsystems.new.info.askName"))
 		fmt.Scanln(&subSystemName)
 		if subSystemName == "" {
-			cmdr.Error.Println(apx.Trans("apx.error.noName"))
+			cmdr.Error.Println(apx.Trans("subsystems.new.error.emptyName"))
 			return nil
 		}
 	}
 
 	if stackName == "" {
-		cmdr.Info.Println(apx.Trans("subsystems.new.info.askStack"))
+		cmdr.Info.Println(apx.Trans("subsystems.new.info.availableStacks"))
 		for i, stack := range stacks {
 			fmt.Printf("%d. %s\n", i+1, stack.Name)
 		}
@@ -219,12 +219,12 @@ func newSubSystem(cmd *cobra.Command, args []string) error {
 		var stackIndex int
 		_, err := fmt.Scanln(&stackIndex)
 		if err != nil {
-			cmdr.Error.Println(apx.Trans("apx.error.invalidInput"))
+			cmdr.Error.Println(apx.Trans("apx.errors.invalidInput"))
 			return nil
 		}
 
 		if stackIndex < 1 || stackIndex > len(stacks) {
-			cmdr.Error.Println(apx.Trans("apx.error.invalidInput"))
+			cmdr.Error.Println(apx.Trans("apx.errors.invalidInput"))
 			return nil
 		}
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -335,6 +335,7 @@ subsystems:
       alreadyExists: "A subsystem with the name '%s' already exists."
     info:
       askName: "Choose a name:"
+      availableStacks: "Available stacks:"
       selectStack: "Select a stack [1-%d]:"
       success: "Created subsystem '%s'."
       creatingSubsystem: "Creating subsystem '%s' with stack '%s'…"


### PR DESCRIPTION
Fix missing or incorrect translation strings and improve readability for subsystem runtime command parsing by breaking down the function.

Pinging @kbdharun again since I had to add missing text.