### PR TITLE
Using Distrobox in PATH

### DIFF
--- a/config/apx.json
+++ b/config/apx.json
@@ -1,5 +1,5 @@
 {
     "apxPath": "/usr/share/apx",
-    "distroboxpath": "/usr/share/apx/distrobox/distrobox",
+    "distroboxPath": "/usr/share/apx/distrobox/distrobox",
     "storageDriver": "overlay"
 }

--- a/settings/config.go
+++ b/settings/config.go
@@ -12,6 +12,7 @@ package settings
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/spf13/viper"
@@ -64,9 +65,23 @@ func GetApxDefaultConfig() (*Config, error) {
 	// 	fmt.Printf("Using config file: %s\n\n", viper.ConfigFileUsed())
 	// }
 
+	distroboxPath := viper.GetString("distroboxPath")
+
+	_, err = os.Stat(distroboxPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			path, err := exec.LookPath("distrobox")
+			if err != nil {
+				fmt.Printf("Unable to find distrobox in PATH.\n")
+			} else {
+				distroboxPath = path
+			}
+		}
+	}
+
 	Cnf := NewApxConfig(
 		viper.GetString("apxPath"),
-		viper.GetString("distroboxPath"),
+		distroboxPath,
 		viper.GetString("storageDriver"),
 	)
 	return Cnf, nil


### PR DESCRIPTION
This closes #362 

During the configuration process, APX will try to locate and utilize Distrobox from the PATH if it is not found in the default path.