### PR TITLE
feat: Bump Orchird to v0.6.0, usage localization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.6
 require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.8.0
-	github.com/vanilla-os/orchid v0.5.0
+	github.com/vanilla-os/orchid v0.6.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,10 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/vanilla-os/orchid v0.5.0 h1:QAOjJ2VcyND5TxK0XYUEu+dysxXicRHhV6i/07S47mk=
 github.com/vanilla-os/orchid v0.5.0/go.mod h1:dNPvHxofO4hEXodEKXp0nLQDZhoHh8evCUXc6X1xLao=
+github.com/vanilla-os/orchid v0.5.1-0.20240617142635-ba1500bd478e h1:j2FjlVF0DrzGO/zVXteqCuuz+YuYii2ksNUFM2x6PkA=
+github.com/vanilla-os/orchid v0.5.1-0.20240617142635-ba1500bd478e/go.mod h1:dNPvHxofO4hEXodEKXp0nLQDZhoHh8evCUXc6X1xLao=
+github.com/vanilla-os/orchid v0.6.0 h1:aH7i621QrqtbspGUie4To28zCk1u1UvGHGzL11wdldE=
+github.com/vanilla-os/orchid v0.6.0/go.mod h1:dNPvHxofO4hEXodEKXp0nLQDZhoHh8evCUXc6X1xLao=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,18 @@ apx:
     invalidInput: "Invalid input."
     invalidChoice: "Invalid choice."
     noRoot: "Do not run Apx as root."
+  msg:
+    help: "Show help for apx."
+    version: "Show version for apx."
+    usage: "Usage"
+    aliases: "Aliases"
+    examples: "Examples"
+    availableCommands: "Available Commands"
+    additionalCommands: "Additional Commands"
+    flags: "Flags"
+    globalFlags: "Global Flags"
+    additionalHelpTopics: "Additional help topics"
+    moreInfo: "Use %s for more information about a command"
   info:
     aborting: "Aborting as requested."
   terminal:

--- a/main.go
+++ b/main.go
@@ -17,9 +17,7 @@ import (
 	"github.com/vanilla-os/orchid/cmdr"
 )
 
-var (
-	Version = "2.4.1"
-)
+var Version = "2.4.1"
 
 //go:embed locales/*.yml
 var fs embed.FS
@@ -38,7 +36,20 @@ func main() {
 
 	// root command
 	root := cmd.NewRootCommand(Version)
-	apx.CreateRootCommand(root)
+	apx.CreateRootCommand(root, apx.Trans("apx.msg.help"), apx.Trans("apx.msg.version"))
+
+	msgs := cmdr.UsageStrings{
+		Usage:                apx.Trans("apx.msg.usage"),
+		Aliases:              apx.Trans("apx.msg.aliases"),
+		Examples:             apx.Trans("apx.msg.examples"),
+		AvailableCommands:    apx.Trans("apx.msg.availableCommands"),
+		AdditionalCommands:   apx.Trans("apx.msg.additionalCommands"),
+		Flags:                apx.Trans("apx.msg.flags"),
+		GlobalFlags:          apx.Trans("apx.msg.globalFlags"),
+		AdditionalHelpTopics: apx.Trans("apx.msg.additionalHelpTopics"),
+		MoreInfo:             apx.Trans("apx.msg.moreInfo"),
+	}
+	apx.SetUsageStrings(msgs)
 
 	// commands
 	stacks := cmd.NewStacksCommand()


### PR DESCRIPTION
Updates liborchid to v0.6.0 which allows us to add translation strings for usage.

@kbdharun this PR adds new strings