### PR TITLE
Make table formatting consistent

### DIFF
--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -241,7 +241,7 @@ func listStacks(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		fmt.Printf(apx.Trans("stacks.list.info.foundStacks"), stacksCount)
+		cmdr.Info.Printfln(apx.Trans("stacks.list.info.foundStacks"), stacksCount)
 
 		table := core.CreateApxTable(os.Stdout)
 		table.SetHeader([]string{apx.Trans("stacks.labels.name"), "Base", apx.Trans("stacks.labels.builtIn"), "Pkgs", "Pkg manager"})


### PR DESCRIPTION
Use the same output function as subsystem for consistent formatting
```
jardon@apx-vso-pico:~/Projects/apx$ ./apx stacks list
Found 1 stacks:┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼
┊ NAME         ┊ BASE         ┊ BUILT-IN ┊ PKGS ┊ PKG MANAGER ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼
┊ ubuntu jammy ┊ ubuntu:jammy ┊ no       ┊ 0    ┊ apt         ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼
```
```
jardon@apx-vso-pico:~/Projects/apx$ ./apx stacks list
 INFO  Found 1 stacks:
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼
┊ NAME         ┊ BASE         ┊ BUILT-IN ┊ PKGS ┊ PKG MANAGER ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼
┊ ubuntu jammy ┊ ubuntu:jammy ┊ no       ┊ 0    ┊ apt         ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼
```