### PR TITLE
fix:[close #393] escape spaces when creating labels

### DIFF
--- a/core/subSystem.go
+++ b/core/subSystem.go
@@ -193,8 +193,8 @@ func (s *SubSystem) Create() error {
 	}
 
 	labels := map[string]string{
-		"stack": s.Stack.Name,
-		"name":  s.Name,
+		"stack": strings.ReplaceAll(s.Stack.Name, " ", "\\ "),
+		"name":  strings.ReplaceAll(s.Name, " ", "\\ "),
 	}
 
 	if s.IsManaged {


### PR DESCRIPTION
- escape spaces when creating stack label
- escape spaces when creating name label

Closes #393