### PR TITLE
fix(Makefile): don't use `sudo`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ build:
 
 install: build
 	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}
-	sudo mkdir -p ${DESTDIR}/etc/apx
+	mkdir -p ${DESTDIR}/etc/apx
 	sed -i 's|/usr/share/apx/distrobox|${PREFIX}/share/apx/distrobox|g' config/apx.json
-	sudo install -Dm644 config/apx.json ${DESTDIR}/etc/apx/apx.json
+	install -Dm644 config/apx.json ${DESTDIR}/etc/apx/apx.json
 	mkdir -p ${DESTDIR}${PREFIX}/share/apx/distrobox
 	sh distrobox/install --prefix ${DESTDIR}${PREFIX}/share/apx/distrobox
 	mv ${DESTDIR}${PREFIX}/share/apx/distrobox/bin/distrobox* ${DESTDIR}${PREFIX}/share/apx/distrobox/.
@@ -22,12 +22,12 @@ install-manpages:
 	chmod 644 ${DESTDIR}${PREFIX}/share/man/man1/apx*
 
 uninstall: uninstall-manpages
-	sudo rm ${DESTDIR}${PREFIX}/bin/apx
-	sudo rm -rf ${DESTDIR}/etc/apx
-	sudo rm -rf ${DESTDIR}${PREFIX}/share/apx
+	rm ${DESTDIR}${PREFIX}/bin/apx
+	rm -rf ${DESTDIR}/etc/apx
+	rm -rf ${DESTDIR}${PREFIX}/share/apx
 
 uninstall-manpages:
-	sudo rm -rf ${DESTDIR}${PREFIX}/share/man/man1/apx*
+	rm -rf ${DESTDIR}${PREFIX}/share/man/man1/apx*
 
 clean:
 	rm -f ${BINARY_NAME}


### PR DESCRIPTION
This is bad practice and users who want to install apx systemwide should invoke `sudo make` themselves.
