### PR TITLE
fix:[#396] increase buffer length for exported bin

### DIFF
--- a/core/subSystem.go
+++ b/core/subSystem.go
@@ -84,6 +84,9 @@ func findExportedBinaries(internalName string) map[string]map[string]string {
 		defer file.Close()
 
 		scanner := bufio.NewScanner(file)
+		const maxTokenSize = 1024 * 1024
+		buf := make([]byte, maxTokenSize)
+		scanner.Buffer(buf, maxTokenSize)
 		for scanner.Scan() {
 			if scanner.Text() == "# distrobox_binary" {
 				scanner.Scan()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,0 @@
-sonar.projectKey=Vanilla-OS_apx_AYiLLt9U9CPJrZw6oxBN
-sonar.projectName=apx
-
-sonar.sources=.
-sonar.exclusions=**/*_test.go
-
-sonar.c.file.suffixes=-
-sonar.cpp.file.suffixes=-
-sonar.objc.file.suffixes=-


### PR DESCRIPTION
Increasing the buffer size silences the error:
```
jardon@lagann:~/Projects/apx$ ./apx subsystems list
error reading binaries: bufio.Scanner: token too long
error reading binaries: bufio.Scanner: token too long
 INFO  Found 1 subsystems:
┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ NAME ┊ STACK       ┊ STATUS  ┊ PKGS ┊
┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ test ┊ vanilla-dev ┊ Created ┊ 0    ┊
┼┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
```

closes #396 