### PR TITLE
fix: move first package in stack packages to list

### DIFF
--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -392,6 +392,7 @@ func updateStack(cmd *cobra.Command, args []string) error {
 	packages, _ := cmd.Flags().GetString("packages")
 	pkgManager, _ := cmd.Flags().GetString("pkg-manager")
 
+	cmdr.Error.Printfln("packages: %s", packages)
 	if name == "" {
 		if len(args) != 1 || args[0] == "" {
 			cmdr.Error.Println(apx.Trans("stacks.update.error.noName"))
@@ -445,11 +446,12 @@ func updateStack(cmd *cobra.Command, args []string) error {
 	}
 
 	packagesArray := strings.Fields(packages)
+	cmdr.Error.Printfln("packagearray: %s", packagesArray)
 	if len(packages) == 0 && !assumeYes {
 		if len(stack.Packages) == 0 {
 			cmdr.Info.Println(apx.Trans("stacks.update.info.noPackages") + "[y/N]")
 		} else {
-			cmdr.Info.Println(apx.Trans("stacks.update.info.confirmPackages"), strings.Join(stack.Packages, "\n\t - "))
+			cmdr.Info.Println(apx.Trans("stacks.update.info.confirmPackages") + "\n\t -", strings.Join(stack.Packages, "\n\t - "))
 		}
 
 		reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
the first item in the list of packages for a stack is not on a new line and is not part of the list at all.  this change moves the package to the beginning of the list for clearer formatting

old:
```
 INFO  Do you want to confirm the current packages list? git
       	 - vim
       	 - neofetch
```

new:
```
 INFO  Do you want to confirm the current packages list?
       	 - git
       	 - vim
       	 - neofetch
```