### PR TITLE
feat:[#399] set pkgm input defaults

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -131,6 +131,7 @@ pkgmanagers:
       askName: "Choose a name:"
       askSudo: "Does the package manager need sudo to run?"
       askCommand: "Enter the command for '%s':"
+      askCommandWithDefault: "Enter the command for '%s' (default: '%s'):"
       askOverwrite: "A package manager with the name '%s' already exists. Overwrite
         it?"
     options:


### PR DESCRIPTION
close [#399]

- add default for autoremove
- add default for purge

I created constant variables for the name of each command, and also created a slice to define the order they should be presented, previously the order of the commands was random

A new translation string was also added 