### PR TITLE
fix:[#420] abort export if bin in $PATH

### DIFF
--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -11,6 +11,7 @@ package cmd
 import (
 	"fmt"
 	"slices"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/apx/v2/core"
@@ -357,9 +358,15 @@ func handleExport(subSystem *core.SubSystem, command, appName, bin, binOutput st
 
 			cmdr.Info.Printfln(apx.Trans("runtimeCommand.info.exportedApp"), appName)
 		} else {
-			err := subSystem.ExportBin(bin, binOutput)
-			if err != nil {
-				return fmt.Errorf(apx.Trans("runtimeCommand.error.exportingBin"), err)
+			_, binErr := exec.LookPath(bin)
+			_, outErr := exec.LookPath(binOutput)
+			if binErr != nil && outErr != nil {
+				err := subSystem.ExportBin(bin, binOutput)
+				if err != nil {
+					return fmt.Errorf(apx.Trans("runtimeCommand.error.exportingBin"), err)
+				}
+			} else {
+				return fmt.Errorf(apx.Trans("runtimeCommand.error.protectedBin"))
 			}
 
 			cmdr.Info.Printfln(apx.Trans("runtimeCommand.info.exportedBin"), bin)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -41,6 +41,7 @@ runtimeCommand:
     unexportingBin: "An error occurred while unexporting the binary: %s"
     startingContainer: "An error occurred while starting the container: %s"
     stoppingContainer: "An error occurred while stopping the container: %s"
+    protectedBin: "Binary already exists on the host."
   info:
     unexportedApps: "Unexported %d applications"
     exportedApps: "Exported %d applications"


### PR DESCRIPTION
- abort if bin or output in $PATH
- en translation for abort message

```bash
$ ./apx snapcraft export -b ls
```
```
Error: Binary already exists on the host.
Usage:
  apx snapcraft export [flags]

Flags:
  -a, --app-name string     The name of the application to export.
  -b, --bin string          The name of the binary to export.
  -o, --bin-output string   Path of the binary output (default: ~/.local/bin/).
  -h, --help                help for export

  ERROR   Binary already exists on the host.
```

closes #420 