### PR TITLE
fix: use formatted println for stack exists error

### DIFF
--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -306,7 +306,7 @@ func newStack(cmd *cobra.Command, args []string) error {
 
 	ok := core.StackExists(name)
 	if ok {
-		cmdr.Error.Println(apx.Trans("stacks.new.error.alreadyExists"))
+		cmdr.Error.Printfln(apx.Trans("stacks.new.error.alreadyExists"), name)
 		return nil
 	}
 


### PR DESCRIPTION
- use formatted println with stack name substitution

```
./apx stacks new
 INFO  Choose a name:
bionic
  ERROR   A stack with the name '%s' already exists.
```
becomes:
```
./apx stacks new
 INFO  Choose a name:
bionic
  ERROR   A stack with the name 'bionic' already exists.
```