### PR TITLE
fix:[#427] refuse to remove stack if in use

### DIFF
--- a/cmd/stacks.go
+++ b/cmd/stacks.go
@@ -488,6 +488,23 @@ func removeStack(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	subSystems, _ := core.ListSubsystemForStack(stackName)
+	if len(subSystems) > 0 {
+		cmdr.Error.Printfln(apx.Trans("stacks.rm.error.inUse"), len(subSystems))
+		table := core.CreateApxTable(os.Stdout)
+		table.SetHeader([]string{apx.Trans("subsystems.labels.name"), "Stack", apx.Trans("subsystems.labels.status"), "Pkgs"})
+		for _, subSystem := range subSystems {
+			table.Append([]string{
+				subSystem.Name,
+				subSystem.Stack.Name,
+				subSystem.Status,
+				fmt.Sprintf("%d", len(subSystem.Stack.Packages)),
+			})
+		}
+		table.Render()
+		return nil
+	}
+
 	force, _ := cmd.Flags().GetBool("force")
 
 	if !force {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -295,6 +295,7 @@ stacks:
     description: "Remove the specified stack."
     error:
       noName: "No name specified."
+      inUse: "The stack is used in %d subsystems:"
     info:
       askConfirmation: "Are you sure you want to remove '%s'?"
       success: "Removed stack '%s'."


### PR DESCRIPTION
- add check for stack in use before removing subsystem
- add error message for in use stack in locales

```bash
./apx stacks rm -n noble
```
```
  ERROR   The stack is used in 1 subsystems:
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ NAME         ┊ STACK ┊ STATUS                   ┊ PKGS ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ vso-waydroid ┊ noble ┊ Exited (130) 5 weeks ago ┊ 0    ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
```

relates #427 