### PR TITLE
Fix/start stop message format

### DIFF
--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -323,7 +323,7 @@ func runPkgCmd(subSystem *core.SubSystem, command string, cmd *cobra.Command, ar
 			return fmt.Errorf(apx.Trans("runtimeCommand.error.startingContainer"), err)
 		}
 
-		cmdr.Info.Printfln(apx.Trans("runtimeCommand.info.startedContainer"), subSystem.Name)
+		cmdr.Info.Printfln(apx.Trans("runtimeCommand.info.startedContainer"))
 	}
 
 	if command == "stop" {
@@ -333,7 +333,7 @@ func runPkgCmd(subSystem *core.SubSystem, command string, cmd *cobra.Command, ar
 			return fmt.Errorf(apx.Trans("runtimeCommand.error.stoppingContainer"), err)
 		}
 
-		cmdr.Info.Printfln(apx.Trans("runtimeCommand.info.stoppedContainer"), subSystem.Name)
+		cmdr.Info.Printfln(apx.Trans("runtimeCommand.info.stoppedContainer"))
 	}
 
 	return nil

--- a/core/dbox.go
+++ b/core/dbox.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+	"io/ioutil"
 )
 
 type dbox struct {
@@ -160,6 +161,8 @@ func (d *dbox) RunCommand(command string, args []string, engineFlags []string, u
 		}
 		return output, err
 	}
+
+	cmd.Stdout = ioutil.Discard
 
 	err := cmd.Run()
 	return nil, err

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -48,10 +48,10 @@ runtimeCommand:
     exportedBin: "Exported binary %s"
     unexportedApp: "Unexported application %s"
     unexportedBin: "Unexported binary %s"
-    startingContainer: "Starting container…"
-    startedContainer: "Started container."
-    stoppingContainer: "Stopping container…"
-    stoppedContainer: "Stopped container."
+    startingContainer: "Starting subsystem %s…"
+    startedContainer: "Started subsystem."
+    stoppingContainer: "Stopping subsystem %s…"
+    stoppedContainer: "Stopped subsystem."
   autoremove:
     description: "Remove packages that are no longer required."
   clean:


### PR DESCRIPTION
this includes two changes:
1. add `%s` to starting/stopping messages
2. silence stdout for non-captureoutput dbox commands.

the second change cleans up the output of the command output which in the case of starting/stopping, silences the distrobox printing the container name for no good reason.  this can be dropped or split out if requested.

```bash
./apx noble stop
```
```
 INFO  Stopping subsystem noble…
 INFO  Stopped subsystem.
```
```bash
./apx noble start
```
```
 INFO  Starting subsystem noble…
 INFO  Started subsystem.
```
closes #431 