### PR TITLE
fix:[#434] exit with 1 if error is detected

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,5 +68,6 @@ func main() {
 	err := apx.Run()
 	if err != nil {
 		cmdr.Error.Println(err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Exit with generic (1) error if error exists
```bash
apx snapcraft run "/usr/bin/echo pass"
```
```
Error: crun: executable file `/usr/bin/echo pass` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
Error: An error occurred while executing the command: exit status 127
Usage:
  apx snapcraft run [flags]

Flags:
  -h, --help   help for run

  ERROR   An error occurred while executing the command: exit status 127
```
```bash
echo $?
```
```
1
```
relates #434 