### PR TITLE
feat: forbid use commands names as container name

### DIFF
--- a/cmd/subsyStems.go
+++ b/cmd/subsyStems.go
@@ -237,6 +237,13 @@ func newSubSystem(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	for _, existcommand := range cmd.Root().Commands() {
+		if subSystemName == existcommand.Name() {
+			cmdr.Error.Printfln(apx.Trans("subsystems.new.error.forbiddenName"), subSystemName)
+			return nil
+		}
+	}
+
 	stack, err := core.LoadStack(stackName)
 	if err != nil {
 		return err

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -349,6 +349,7 @@ subsystems:
       noStacks: "A stack is needed to create a subsystem. Create a new one with 'apx
         stacks new' or contact the system administrator."
       emptyName: "The name cannot be empty."
+      forbiddenName: "The name '%s' is forbidden. Please choose a different name"
       noName: "No name specified."
       emptyStack: "The stack cannot be empty."
       noStack: "No stack specified."


### PR DESCRIPTION
closes: #437 

While testing this in a virtual machine I noticed that apx-gui can create containers with command names so this needs to be fixed in apx-gui as well (they cannot be used as containers, they are just displayed in the panel and when trying to use them in apx-gui they display the output of the command)
![Screenshot From 2024-12-14 20-35-10](https://github.com/user-attachments/assets/a30f5f25-014d-46af-ad1f-06dcee4320bf)
