### PR TITLE
fix:[#449] remove stdout discard

### DIFF
--- a/core/dbox.go
+++ b/core/dbox.go
@@ -17,7 +17,6 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
-	"io/ioutil"
 )
 
 type dbox struct {
@@ -161,8 +160,6 @@ func (d *dbox) RunCommand(command string, args []string, engineFlags []string, u
 		}
 		return output, err
 	}
-
-	cmd.Stdout = ioutil.Discard
 
 	err := cmd.Run()
 	return nil, err


### PR DESCRIPTION
remove the ioutil discard on stdout. 

```bash
APX_VERBOSE=1 ./apx test-apx enter
```
```
Runing a command:
	Command: /usr/bin/podman ps -a --format {{.ID}}|{{.CreatedAt}}|{{.Status}}|{{.Labels}}|{{.Names}}
	captureOutput: true
	muteOutput: false
	rootFull: false
	detachedMode: false
Runing a command:
	Command: /usr/share/apx/distrobox/distrobox enter apx-test-apx
	captureOutput: false
	muteOutput: false
	rootFull: false
	detachedMode: false
jardon@apx-test-apx:/var/home/jardon/Projects/apx$ exit
```

closes #449 