### PR TITLE
fix:[#450] increase exported bin scan buffer token size

### DIFF
--- a/core/subSystem.go
+++ b/core/subSystem.go
@@ -84,7 +84,7 @@ func findExportedBinaries(internalName string) map[string]map[string]string {
 		defer file.Close()
 
 		scanner := bufio.NewScanner(file)
-		const maxTokenSize = 1024 * 1024
+		const maxTokenSize = 1024 * 2048
 		buf := make([]byte, maxTokenSize)
 		scanner.Buffer(buf, maxTokenSize)
 		for scanner.Scan() {


### PR DESCRIPTION
increase the subsystem exported binary scanner buffer token size.

closes #450