### PR TITLE
fix:[#454] list all subsystems for stack

### DIFF
--- a/core/subSystem.go
+++ b/core/subSystem.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -315,10 +316,19 @@ func ListSubsystemForStack(stackName string) ([]*SubSystem, error) {
 		return nil, err
 	}
 
-	containers, err := dbox.ListContainers(true)
+	rootlessContainers, err := dbox.ListContainers(false)
+
 	if err != nil {
 		return nil, err
 	}
+
+	rootfullContainers, err := dbox.ListContainers(true)
+
+	if err != nil {
+		return nil, err
+	}
+
+	containers := slices.Concat(rootlessContainers, rootfullContainers)
 
 	subsystems := []*SubSystem{}
 	for _, container := range containers {


### PR DESCRIPTION
check for both rootful and rootless containers instead of just rootful
```
Running a command:
	Command: /usr/bin/podman ps -a --format {{.ID}}|{{.CreatedAt}}|{{.Status}}|{{.Labels}}|{{.Names}}
	captureOutput: true
	muteOutput: false
	rootFull: false
	detachedMode: false
Running a command:
	Command: /usr/bin/podman ps -a --format {{.ID}}|{{.CreatedAt}}|{{.Status}}|{{.Labels}}|{{.Names}}
	captureOutput: true
	muteOutput: false
	rootFull: false
	detachedMode: false
Running a command:
	Command: /usr/bin/pkexec /usr/bin/podman ps -a --format {{.ID}}|{{.CreatedAt}}|{{.Status}}|{{.Labels}}|{{.Names}}
	captureOutput: true
	muteOutput: false
	rootFull: true
	detachedMode: false
  ERROR   The stack is used in 5 subsystems:
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ NAME          ┊ STACK  ┊ STATUS                    ┊ PKGS ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ vso-pico      ┊ bionic ┊ Up 3 days                 ┊ 0    ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ test-apx      ┊ bionic ┊ Up 3 days                 ┊ 0    ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ test-rm-stack ┊ bionic ┊ Created                   ┊ 0    ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ test-pkexec   ┊ bionic ┊ Created                   ┊ 0    ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
┊ vso-waydroid  ┊ bionic ┊ Exited (130) 5 months ago ┊ 0    ┊
┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┼┄┄┄┄┄┄┼
```

closes #454 