### PR TITLE
fix: makefile build needs to build in cmd dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: clean build
 build: ${BINARY_NAME}
 
 ${BINARY_NAME}:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -a -tags netgo -ldflags '-w -extldflags "-static"' -o $@
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -a -tags netgo -ldflags '-w -extldflags "-static"' -o $@ ./cmd
 
 install: build
 	install -Dm755 ${BINARY_NAME} ${DESTDIR}${PREFIX}/bin/${BINARY_NAME}


### PR DESCRIPTION
When following build instructions in readme the following output is generated upon `make build`
```
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o apx
no Go files in /path/to/apx
make: *** [Makefile:12: apx] Error 1
```
The fix is to make it point to the cmd directory.