### PR TITLE
fix:[#476] return error code on stack delete failure

### DIFF
--- a/internal/cli/stacks.go
+++ b/internal/cli/stacks.go
@@ -284,7 +284,7 @@ func (c *StacksRmCmd) Run() error {
 			})
 		}
 		Apx.CLI.Table(headers, data)
-		return nil
+    		return fmt.Errorf(Apx.LC.Get("stacks.rm.error.inUse"), len(subSystems))
 	}
 
 	if !c.Force {

--- a/internal/cli/stacks.go
+++ b/internal/cli/stacks.go
@@ -284,7 +284,7 @@ func (c *StacksRmCmd) Run() error {
 			})
 		}
 		Apx.CLI.Table(headers, data)
-    		return fmt.Errorf(Apx.LC.Get("stacks.rm.error.inUse"), len(subSystems))
+		return fmt.Errorf(Apx.LC.Get("stacks.rm.error.inUse"), len(subSystems))
 	}
 
 	if !c.Force {


### PR DESCRIPTION
Properly returns an error when attempting to delete a stack that is currently used by subsystems.

Note: there are similar places in this source file where there are logged errors but a `return nil`. Not sure if those should also be looked at but may lead to similar issues in the future.

Closes: #476 