### PR TITLE
adds optional distrobox arguments to subsystems

### DIFF
--- a/core/dbox.go
+++ b/core/dbox.go
@@ -260,7 +260,7 @@ func (d *dbox) ContainerDelete(name string, rootFull bool) error {
 	return err
 }
 
-func (d *dbox) CreateContainer(name string, image string, additionalPackages []string, home string, labels map[string]string, withInit bool, rootFull bool, unshared bool, withNvidiaIntegration bool, hostname string) error {
+func (d *dbox) CreateContainer(name string, image string, additionalPackages []string, home string, labels map[string]string, withInit bool, rootFull bool, unshared bool, withNvidiaIntegration bool, hostname string, additionalArgs ...string) error {
 	args := []string{
 		"--image", image,
 		"--name", name,
@@ -293,6 +293,8 @@ func (d *dbox) CreateContainer(name string, image string, additionalPackages []s
 		args = append(args, "--additional-packages")
 		args = append(args, strings.Join(additionalPackages, " "))
 	}
+
+	args = append(args, additionalArgs...)
 
 	engineFlags := []string{}
 	for key, value := range labels {

--- a/core/subsystem.go
+++ b/core/subsystem.go
@@ -34,9 +34,10 @@ type SubSystem struct {
 	IsUnshared           bool
 	HasNvidiaIntegration bool
 	Hostname             string
+	AdditionalArgs       []string
 }
 
-func NewSubSystem(name string, stack *Stack, home string, hasInit bool, isManaged bool, isRootfull bool, isUnshared bool, hasNvidiaIntegration bool, hostname string) (*SubSystem, error) {
+func NewSubSystem(name string, stack *Stack, home string, hasInit bool, isManaged bool, isRootfull bool, isUnshared bool, hasNvidiaIntegration bool, hostname string, additionalArgs ...string) (*SubSystem, error) {
 	internalName := genInternalName(name)
 	return &SubSystem{
 		InternalName:         internalName,
@@ -49,6 +50,7 @@ func NewSubSystem(name string, stack *Stack, home string, hasInit bool, isManage
 		IsUnshared:           isUnshared,
 		HasNvidiaIntegration: hasNvidiaIntegration,
 		Hostname:             hostname,
+		AdditionalArgs:       additionalArgs,
 	}, nil
 }
 
@@ -221,6 +223,7 @@ func (s *SubSystem) Create() error {
 		s.IsUnshared,
 		s.HasNvidiaIntegration,
 		s.Hostname,
+		s.AdditionalArgs...,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds the ability to pass optional arguments to distrobox, while keeping it compatible by making the arguments optional.

I chose this approach because I thought just adding every argument manually doesn't make sense in the long run.
Making this accessible through the cli might be something we want to do but that needs to be done carefully since it requires escaping the arguments properly. 